### PR TITLE
[MOB-1758] - Icon fixes for Sample App Android

### DIFF
--- a/SampleApp/android/app/build.gradle
+++ b/SampleApp/android/app/build.gradle
@@ -199,3 +199,4 @@ task copyDownloadableDepsToLibs(type: Copy) {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
+apply from: file("../../node_modules/react-native-vector-icons/fonts.gradle")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iterable/react-native-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Iterable SDK for React Native.",
   "main": "./js/index.js",
   "types": "./js/index.d.ts",


### PR DESCRIPTION
For Android to load react native vector images, we had to include that in app's gradle file which was missing.