### PR TITLE
[MOB-1893] - Access IterableSDK methods from RN Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ def getModuleVersion() {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.iterable:iterableapi:3.2.4'
+    api 'com.iterable:iterableapi:3.2.4'
 }


### PR DESCRIPTION
Adding dependency using `api` keyword instead of `implementation` allows chained access to library. This allows app to use methods from internal library. More description given in the JIRA ticket with stack overflow link