### PR TITLE
[MOB-1922] - Update RN Android to 3.2.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ def getModuleVersion() {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'com.iterable:iterableapi:3.2.4'
+    api 'com.iterable:iterableapi:3.2.5'
 }


### PR DESCRIPTION
This update will solve problems where trackInAppClick were not getting registered.
Also, going forward, we can update the Android Version in RNSDK as a part of release process if everything looks okay.