### PR TITLE
Bug Fix: Android app not focused when using urlHandler or customActionHandler

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -348,7 +348,8 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         } catch (JSONException e) {
             IterableLogger.e(TAG, "Failed handling custom action");
         }
-        return true;
+        // The Android SDK will not bring the app into focus is this is `true`. It still respects the `openApp` bool flag.
+        return false;
     }
 
     @NonNull
@@ -386,7 +387,8 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         } catch (JSONException e) {
             IterableLogger.e(TAG, e.getLocalizedMessage());
         }
-        return true;
+        // The Android SDK will not bring the app into focus is this is `true`. It still respects the `openApp` bool flag.
+        return false;
     }
 
     // ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #76.

I went tracing through this and [iterable/iterable-android-sdk](https://github.com/Iterable/iterable-android-sdk) to figure out why we had some many issues with our Android app not bring brought into focus. I'll lay out what I found here, starting at the top level.

1. The actual `config.customActionHandler` you assign is fired [here](https://github.com/Iterable/react-native-sdk/blob/baea2e90c162d6bac72ab6a9f188f82cef5b5e8a/ts/Iterable.ts#L199), via `RNEventEmitter`. Note that nothing is actually done with the return value from your JS handler.

2. The event which executes the above is triggered in native Android [here](https://github.com/Iterable/react-native-sdk/blob/459201fa5da4d3022c69a9e7ad528d38ea63e581/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java#L382). The key issue here is **this function always returns `true`**, which tells the native code that any custom urls/actions are always handled. This also happens for [urls](https://github.com/Iterable/react-native-sdk/blob/459201fa5da4d3022c69a9e7ad528d38ea63e581/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java#L434).

3. The above function is called [here](https://github.com/Iterable/iterable-android-sdk/blob/817d006f7776a71f0b7beeef347e9dd666283dda/iterableapi/src/main/java/com/iterable/iterableapi/IterableActionRunner.java#L89), where if we have a `customActionHandler` defined, then we return the result of the above (which as we saw, is always `true`). Otherwise we return `false`.

4. The problem comes [here](https://github.com/Iterable/iterable-android-sdk/blob/85edd3322a442b733b5bc2a19a3f1b1aa2c57591/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java#L83), where we execute the action, and if `handled === true` than we don't bring the app into focus. I believe this may have been doing sensibly for native `Android` apps, where they want to intercept a URL/action and can easily bring the app into foreground. However this is not the same for RN, as this code need to be run on native side.

I initially created a [fork of `iterable/iterable-android-sdk`](https://github.com/Iterable/iterable-android-sdk/compare/3.2.4...ourfabriq:fork/3.2.4-android-focus) which fixed the issue, but I later realize it would likely to be easier to fix for the RN use case, without breaking changes to the existing `iterable-android-sdk`, if we made the changes in this PR.