### PR TITLE
[MOB-2591] - Update Android dependency to 3.2.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ def getModuleVersion() {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'com.iterable:iterableapi:3.3.0-beta1'
+    api 'com.iterable:iterableapi:3.2.10'
 }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-2591

## ✏️ Description

This will update the Android dependency to 3.2.10 which takes care of `firebase_database_url` error faced by some customers