### PR TITLE
[MOB-2731] add case for auth token retrieval timing out

### DIFF
--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -573,7 +573,10 @@ extension ReactIterableAPI: IterableAuthDelegate {
                 }
             } else {
                 ITBInfo("authTokenRetrieval timed out")
-                completion(nil)
+                
+                DispatchQueue.main.async {
+                    completion(nil)
+                }
             }
         }
     }

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -571,6 +571,9 @@ extension ReactIterableAPI: IterableAuthDelegate {
                 DispatchQueue.main.async {
                     completion(self.passedAuthToken)
                 }
+            } else {
+                ITBInfo("authTokenRetrieval timed out")
+                completion(nil)
             }
         }
     }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-2731](https://iterable.atlassian.net/browse/MOB-2731)

## ✏️ Description

* add a catch for when the auth retrieval times out in the RN + iOS bridge
