### PR TITLE
Fixes for setting autoDisplayPaused flag in correct threads

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
@@ -32,6 +33,7 @@ import com.iterable.iterableapi.IterableInAppMessage;
 import com.iterable.iterableapi.IterableLogger;
 import com.iterable.iterableapi.IterableUrlHandler;
 import com.iterable.iterableapi.RNIterableInternal;
+
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -360,10 +362,14 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     }
 
     @ReactMethod
-    public void setAutoDisplayPaused(boolean paused) {
+    public void setAutoDisplayPaused(final boolean paused) {
         IterableLogger.printInfo();
-
-        IterableApi.getInstance().getInAppManager().setAutoDisplayPaused(paused);
+        UiThreadUtil.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                IterableApi.getInstance().getInAppManager().setAutoDisplayPaused(paused);
+            }
+        });
     }
 
     // ---------------------------------------------------------------------------------------

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -392,7 +392,9 @@ class ReactIterableAPI: RCTEventEmitter {
     func set(autoDisplayPaused: Bool) {
         ITBInfo()
         
-        IterableAPI.inAppManager.isAutoDisplayPaused = autoDisplayPaused
+        DispatchQueue.main.async {
+            IterableAPI.inAppManager.isAutoDisplayPaused = autoDisplayPaused
+        }
     }
     
     @objc(passAlongAuthToken:)


### PR DESCRIPTION

## ✏️ Description

> Please provide a brief description of what this pull request does.

These changes fix a crash on Android when calling this method from non-UI thread contexts (ie setTimeout in JS); iOS needed similar edits to fix functionality although a crash wasn't occurring there