### PR TITLE
Added a dummy promise that returns true for android API initialization

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -69,7 +69,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     }
 
     @ReactMethod
-    public void initializeWithApiKey(String apiKey, ReadableMap configReadableMap, String version) {
+    public void initializeWithApiKey(String apiKey, ReadableMap configReadableMap, String version, Promise promise) {
         IterableLogger.d(TAG, "initializeWithApiKey: " + apiKey);
         IterableConfig.Builder configBuilder = Serialization.getConfigFromReadableMap(configReadableMap);
 
@@ -91,6 +91,9 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
         IterableApi.initialize(reactContext, apiKey, configBuilder.build());
         IterableApi.getInstance().setDeviceAttribute("reactNativeSDKVersion", version);
+        // TODO: Figure out what the error cases are and handle them appropriately
+        // This is just here to match the TS types and let the JS thread know when we are done initializing
+        promise.resolve(true);
     }
 
     @ReactMethod


### PR DESCRIPTION
## ✏️ Description

Fixes #167
This makes it match the iOS signature and fulfills what typescript says will be there.

This does not actually handle any errors so that should probably be added at some point in the future. This is mostly just to unblock ourselves as we are implementing the SDK. If someone wants to point me into the right direction for errors that I should be checking for then I am happy to do so. I see this as a small step in the right direction to prevent valid typescript applications from crashing unexpectedly.