### PR TITLE
[MOB - 3091] - Sync InApp on first launch

### DIFF
--- a/android/src/main/java/com/iterable/iterableapi/RNIterableInternal.java
+++ b/android/src/main/java/com/iterable/iterableapi/RNIterableInternal.java
@@ -36,4 +36,8 @@ public class RNIterableInternal {
         IterableApi.getInstance().setAttributionInfo(attributionInfo);
     }
 
+    public static void syncInApp() {
+        IterableApi.getInstance().getInAppManager().syncInApp();
+    }
+
 }

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -91,6 +91,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
         IterableApi.initialize(reactContext, apiKey, configBuilder.build());
         IterableApi.getInstance().setDeviceAttribute("reactNativeSDKVersion", version);
+        RNIterableInternal.syncInApp();
     }
 
     @ReactMethod


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-3091

## ✏️ Description

1. SDK Initialization now calls syncInApp internally.

This is because Android's InAppManager class is not attached to lifecycle of RN Android app at the very first launch and misses on calling syncInApp(), thus leading to failure in showing any new in-app messages.

Tested on Dev App
1. InApp sent in background while the app was killed is shown when the app starts up.
2. Backgrounding and Foregrounding the app does not call getMessages repeatedly as initialization is not called every time the app starts up. This means it becomes the job of developer to make sure initialization is not called repeatedly to avoid unnecessary getMessages call.