### PR TITLE
[MOB - 3301] - urlHandler to return true

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -453,8 +453,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         } catch (JSONException e) {
             IterableLogger.e(TAG, e.getLocalizedMessage());
         }
-        // The Android SDK will not bring the app into focus is this is `true`. It still respects the `openApp` bool flag.
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-3301

## ✏️ Description

When a deeplink is clicked, IterableURLHandler in RN Bridge previously returned false regardless of whether the deeplink was handled or not handled.
This results in situation where deeplink will also be handled via client’s callback code, PLUS Iterable will try opening the link on browser.
To keep consistency with iOS, Android bridging code should also return true indicating that “deeplink urlcallback will be taken care by developers” and no need to further go and open links.

This also means that open URL functionality for React Native for deep links AND push notification wont work anymore.
