### PR TITLE
[MOB-3340] - CustomAction Handler returns

### DIFF
--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -450,7 +450,8 @@ class Iterable {
         (dict) => {
           const action = IterableAction.fromDict(dict["action"])
           const context = IterableActionContext.fromDict(dict["context"])
-          config.customActionHandler!(action, context)
+          const result = config.customActionHandler!(action, context)
+          RNIterableAPI.setCustomActionHandled(result)
         }
       )
     }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

https://iterable.atlassian.net/browse/MOB-3340

## ✏️ Description

This commit will allow Bridging code to pass values from JS customActionHandler to our Android SDK. Thus letting SDK perform task at this [line](https://github.com/Iterable/iterable-android-sdk/blob/be11d3cc439dd882979049207a90a96ea0b93cb4/iterableapi/src/main/java/com/iterable/iterableapi/IterablePushActionReceiver.java#L100) properly.

However, it wont still be able to perform customAction in background if app is killed. In such cases, it will open the app and perform customAction.
