### PR TITLE
react-native 0.65 android event emitter stubs

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -473,6 +473,16 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         }
     }
 
+    @ReactMethod
+    public void addListener(String eventName) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    public void removeListeners(Integer count) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
     // ---------------------------------------------------------------------------------------
     // endregion
 


### PR DESCRIPTION
## Description

This PR stops the following warnings that are are being triggered on React Native 0.65 on Android:

- ``WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `addListener` method.``
- ``WARN  `new NativeEventEmitter()` was called with a non-null argument without the required `removeListeners` method.``

 The warnings are due to this commit in the react-native repo: https://github.com/facebook/react-native/commit/114be1d2170bae2d29da749c07b45acf931e51e2

Here are a few examples of the same fix being applied in other repos as well:

- https://github.com/software-mansion/react-native-reanimated/pull/2316/files
- https://github.com/notifee/react-native-notifee/pull/368/files
- https://github.com/invertase/react-native-firebase/pull/5616/files