### PR TITLE
[MOB-3362] create and use wrapped dataFields serialization

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -121,18 +121,14 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
     @ReactMethod
     public void setUserId(@Nullable String userId) {
-        IterableLogger.d(TAG, "setUserId");
+        IterableLogger.d(TAG, "setUserId: " + userId);
         IterableApi.getInstance().setUserId(userId);
     }
 
     @ReactMethod
     public void updateUser(ReadableMap dataFields, Boolean mergeNestedObjects) {
-        IterableLogger.v(TAG, "Update User");
-        try {
-            IterableApi.getInstance().updateUser(Serialization.convertMapToJson(dataFields));
-        } catch (JSONException e) {
-            IterableLogger.e(TAG, "Failed passing dataFields to updateUser API");
-        }
+        IterableLogger.v(TAG, "updateUser");
+        IterableApi.getInstance().updateUser(optSerializedDataFields(dataFields));
     }
 
     @ReactMethod
@@ -142,45 +138,25 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
     @ReactMethod
     public void trackEvent(String name, ReadableMap dataFields) {
-        try {
-            IterableApi.getInstance().track(name, Serialization.convertMapToJson(dataFields));
-        } catch (JSONException e) {
-            IterableLogger.e(TAG, "Failed to convert datafields to JSON");
-        }
+        IterableLogger.v(TAG, "trackEvent");
+        IterableApi.getInstance().track(name, optSerializedDataFields(dataFields));
     }
 
     @ReactMethod
     public void updateCart(ReadableArray items) {
-        IterableLogger.v(TAG, "UpdateCart API");
-
+        IterableLogger.v(TAG, "updateCart");
         IterableApi.getInstance().updateCart(Serialization.commerceItemsFromReadableArray(items));
     }
 
     @ReactMethod
     public void trackPurchase(Double total, ReadableArray items, ReadableMap dataFields) {
-        IterableLogger.v(TAG, "TrackPurchase API");
-        JSONObject dataFieldsJson = null;
-        try {
-            if (dataFields != null) {
-                dataFieldsJson = Serialization.convertMapToJson(dataFields);
-            }
-        } catch (JSONException e) {
-            IterableLogger.e(TAG, "Failed converting JSON to object");
-        }
-        IterableApi.getInstance().trackPurchase(total, Serialization.commerceItemsFromReadableArray(items), dataFieldsJson);
+        IterableLogger.v(TAG, "trackPurchase");
+        IterableApi.getInstance().trackPurchase(total, Serialization.commerceItemsFromReadableArray(items), optSerializedDataFields(dataFields));
     }
 
     @ReactMethod
     public void trackPushOpenWithCampaignId(Integer campaignId, Integer templateId, String messageId, Boolean appAlreadyRunning, ReadableMap dataFields) {
-        JSONObject dataFieldsJson = null;
-        if (dataFields != null) {
-            try {
-                dataFieldsJson = Serialization.convertMapToJson(dataFields);
-            } catch (JSONException e) {
-                IterableLogger.d(TAG, "Failed to convert to JSON");
-            }
-        }
-        RNIterableInternal.trackPushOpenWithCampaignId(campaignId, templateId, messageId, dataFieldsJson);
+        RNIterableInternal.trackPushOpenWithCampaignId(campaignId, templateId, messageId, optSerializedDataFields(dataFields));
     }
 
     @ReactMethod
@@ -218,22 +194,33 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
     @ReactMethod
     public void setReadForMessage(String messageId, boolean read) {
+        IterableLogger.v(TAG, "setReadForMessage");
         IterableApi.getInstance().getInAppManager().setRead(RNIterableInternal.getMessageById(messageId), read);
+    }
+
+    @ReactMethod
+    public void removeMessage(String messageId, Integer location, Integer deleteSource) {
+        IterableLogger.v(TAG, "removeMessage");
+        IterableApi.getInstance().getInAppManager().removeMessage(RNIterableInternal.getMessageById(messageId), Serialization.getIterableDeleteActionTypeFromInteger(deleteSource), Serialization.getIterableInAppLocationFromInteger(location));
     }
 
     @ReactMethod
     public void getHtmlInAppContentForMessage(String messageId, final Promise promise) {
         IterableLogger.printInfo();
         IterableInAppMessage message = RNIterableInternal.getMessageById(messageId);
+
         if (message == null) {
             promise.reject("", "Could not find message with id: " + messageId);
             return;
         }
+
         JSONObject messageContent = Serialization.messageContentToJsonObject(message.getContent());
+
         if (messageContent == null) {
             promise.reject("", "messageContent is null for message id: " + messageId);
             return;
         }
+
         try {
             promise.resolve(Serialization.convertJsonToMap(messageContent));
         } catch (JSONException e) {
@@ -282,7 +269,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
     @ReactMethod
     public void disableDeviceForCurrentUser() {
-        IterableLogger.v(TAG, "Disable Device");
+        IterableLogger.v(TAG, "disableDevice");
         IterableApi.getInstance().disablePush();
     }
 
@@ -396,6 +383,20 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         return integers;
     }
 
+    @Nullable
+    private static JSONObject optSerializedDataFields(ReadableMap dataFields) {
+        JSONObject dataFieldsJson = null;
+
+        if (dataFields != null) {
+            try {
+                dataFieldsJson = Serialization.convertMapToJson(dataFields);
+            } catch (JSONException e) {
+                IterableLogger.d(TAG, "Failed to convert dataFields to JSON");
+            }
+        }
+
+        return dataFieldsJson;
+    }
 
     // ---------------------------------------------------------------------------------------
     // region IterableSDK callbacks


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3362](https://iterable.atlassian.net/browse/MOB-3362)

## ✏️ Description

* creates and wraps the `dataFields` serialization to allow `null`
* slight formatting consistency changes
* fixes https://github.com/Iterable/react-native-sdk/issues/198
