### PR TITLE
[MOB-3672] allow track in app close to take null clickedUrl

### DIFF
--- a/android/src/main/java/com/iterable/iterableapi/RNIterableInternal.java
+++ b/android/src/main/java/com/iterable/iterableapi/RNIterableInternal.java
@@ -23,11 +23,7 @@ public class RNIterableInternal {
     public static IterableInAppMessage getMessageById(String messageId) {
         return IterableApi.getInstance().getInAppManager().getMessageById(messageId);
     }
-
-    public static void trackInAppClose(String messageId, String clickedUrl, IterableInAppCloseAction closeAction, IterableInAppLocation location) {
-        IterableApi.getInstance().trackInAppClose(messageId, clickedUrl, closeAction, location);
-    }
-
+    
     public static void trackPushOpenWithCampaignId(Integer campaignId, Integer templateId, String messageId, @Nullable JSONObject dataFields) {
         IterableApi.getInstance().trackPushOpen(campaignId, templateId, messageId, dataFields);
     }

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -290,10 +290,12 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     @ReactMethod
     public void trackInAppOpen(String messageId, @Nullable Integer location) {
         IterableInAppMessage message = RNIterableInternal.getMessageById(messageId);
+
         if (message == null) {
-            IterableLogger.d(TAG, "Failed to get InApp for message id : " + messageId);
+            IterableLogger.d(TAG, "Failed to get in-app for message ID: " + messageId);
             return;
         }
+
         IterableApi.getInstance().trackInAppOpen(message, Serialization.getIterableInAppLocationFromInteger(location));
     }
 
@@ -301,30 +303,46 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     public void trackInAppClick(String messageId, @Nullable Integer location, String clickedUrl) {
         IterableInAppMessage message = RNIterableInternal.getMessageById(messageId);
         IterableInAppLocation inAppOpenLocation = Serialization.getIterableInAppLocationFromInteger(location);
+
         if (message == null) {
-            IterableLogger.d(TAG, "Failed to get InApp for message id : " + messageId);
+            IterableLogger.d(TAG, "Failed to get in-app for message ID: " + messageId);
             return;
         }
+
         if (clickedUrl == null) {
-            IterableLogger.d(TAG, "clickedURL is null");
+            IterableLogger.d(TAG, "clickedUrl is null");
             return;
         }
+
         if (inAppOpenLocation == null) {
             IterableLogger.d(TAG, "in-app open location is null");
             return;
         }
+
         IterableApi.getInstance().trackInAppClick(message, clickedUrl, inAppOpenLocation);
     }
 
     @ReactMethod
-    public void trackInAppClose(String messageId, Integer location, Integer source, String clickedUrl) {
+    public void trackInAppClose(String messageId, Integer location, Integer source, @Nullable String clickedUrl) {
+        IterableInAppMessage inAppMessage = RNIterableInternal.getMessageById(messageId);
         IterableInAppLocation inAppCloseLocation = Serialization.getIterableInAppLocationFromInteger(location);
         IterableInAppCloseAction closeAction = Serialization.getIterableInAppCloseSourceFromInteger(source);
-        if (messageId == null || clickedUrl == null || inAppCloseLocation == null || closeAction == null) {
-            IterableLogger.d(TAG, "null parameter passed to IterableAPI API");
+
+        if (inAppMessage == null) {
+            IterableLogger.d(TAG, "Failed to get in-app for message ID: " + messageId);
             return;
         }
-        RNIterableInternal.trackInAppClose(messageId, clickedUrl, closeAction, inAppCloseLocation);
+
+        if (inAppCloseLocation == null) {
+            IterableLogger.d(TAG, "in-app close location is null");
+            return;
+        }
+
+        if (closeAction == null) {
+            IterableLogger.d(TAG, "in-app close action is null");
+        }
+
+        IterableApi.getInstance().trackInAppClose(inAppMessage, clickedUrl, inAppCloseLocation, closeAction);
     }
     // ---------------------------------------------------------------------------------------
     // endregion

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -342,7 +342,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
             IterableLogger.d(TAG, "in-app close action is null");
         }
 
-        IterableApi.getInstance().trackInAppClose(inAppMessage, clickedUrl, inAppCloseLocation, closeAction);
+        IterableApi.getInstance().trackInAppClose(inAppMessage, clickedUrl, closeAction, inAppCloseLocation);
     }
     // ---------------------------------------------------------------------------------------
     // endregion

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -340,6 +340,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
 
         if (closeAction == null) {
             IterableLogger.d(TAG, "in-app close action is null");
+            return;
         }
 
         IterableApi.getInstance().trackInAppClose(inAppMessage, clickedUrl, closeAction, inAppCloseLocation);

--- a/ios/RNIterableAPI/RNIterableAPI.m
+++ b/ios/RNIterableAPI/RNIterableAPI.m
@@ -66,7 +66,7 @@ RCT_EXTERN_METHOD(trackInAppClick: (nonnull NSString *) messageId
 RCT_EXTERN_METHOD(trackInAppClose: (nonnull NSString *) messageId
                   location: (nonnull NSNumber *) location
                   source: (nonnull NSNumber *) source
-                  clickedUrl: (nonnull NSString *) clickedUrl)
+                  clickedUrl: (NSString *) clickedUrl)
 
 RCT_EXTERN_METHOD(inAppConsume: (nonnull NSString *) messageId
                   location: (nonnull NSNumber *) location

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -216,7 +216,7 @@ class ReactIterableAPI: RCTEventEmitter {
     func trackInAppClose(messageId: String,
                          location locationNumber: NSNumber,
                          source sourceNumber: NSNumber,
-                         clickedUrl: String) {
+                         clickedUrl: String?) {
         ITBInfo()
         
         guard let message = IterableAPI.inAppManager.getMessage(withId: messageId) else {

--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -367,7 +367,7 @@ class Iterable {
   * @param {IterableInAppCloseSource} source
   * @param {string} clickedUrl 
   */
-  static trackInAppClose(message: IterableInAppMessage, location: IterableInAppLocation, source: IterableInAppCloseSource, clickedUrl: string) {
+  static trackInAppClose(message: IterableInAppMessage, location: IterableInAppLocation, source: IterableInAppCloseSource, clickedUrl: string | undefined) {
     console.log("trackInAppClose")
     RNIterableAPI.trackInAppClose(message.messageId, location, source, clickedUrl)
   }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3672](https://iterable.atlassian.net/browse/MOB-3672)

## ✏️ Description

* allows `trackInAppClose` to take a `null` `clickedUrl` parameter when there's no associated URL with the event (e.g. back button or `dismiss`)
* slight refactoring to use standardized API calls