### PR TITLE
[MOB-3734] address inbox event errors

### DIFF
--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -96,6 +96,8 @@ const IterableInboxMessageDisplay = ({
       
       if(URL === 'iterable://dismiss') {
          Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link)
+         returnToInbox()
+         return
       }
 
       if (URL.slice(0, 4) === 'http') {
@@ -103,11 +105,10 @@ const IterableInboxMessageDisplay = ({
       }
 
       if(Iterable.savedConfig.urlHandler) {
-         if(!Iterable.savedConfig.urlHandler(URL, context)) {
-            Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link)
-         }
-      } 
+         Iterable.savedConfig.urlHandler(URL, context)
+      }
       
+      Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link) 
       returnToInbox()
    }
 


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3734](https://iterable.atlassian.net/browse/MOB-3734)

## ✏️ Description

This pull request addresses some errors I discovered when testing the inbox events. The close events were being counted twice when dismiss button was clicked. Also, a close event was not being registered for the deep link buttons. Now, close events are registered for both the invalid link and the deep link. I matched this functionality with the iOS inbox.
