### PR TITLE
[MOB-3735] addresses delete link warning

### DIFF
--- a/ts/IterableInboxMessageCell.tsx
+++ b/ts/IterableInboxMessageCell.tsx
@@ -1,6 +1,6 @@
 'use strict'
 
-import React, { useRef, useEffect } from 'react'
+import React, { useRef } from 'react'
 import {
    View,
    Text,

--- a/ts/IterableInboxMessageCell.tsx
+++ b/ts/IterableInboxMessageCell.tsx
@@ -1,6 +1,6 @@
 'use strict'
 
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import {
    View,
    Text,

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -75,10 +75,14 @@ const IterableInboxMessageDisplay = ({
    `
 
    useEffect(() => {
+      let mounted = true
       inAppContentPromise.then(
          (value) => {
-            setInAppContent(value)
+            if(mounted) {
+               setInAppContent(value)
+            }
          })
+      return () => {mounted = false}
    })
 
    const handleHTMLMessage = (event: any) => {


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3735] (https://iterable.atlassian.net/browse/MOB-3735)

## ✏️ Description

A warning occurs when the delete link or button within the in-app message is clicked on the last message in the message list. 

<img width="398" alt="Screen Shot 2021-11-17 at 3 30 42 PM" src="https://user-images.githubusercontent.com/86252206/142292986-ca272ef5-bd4a-4b53-b580-12e2551805b8.png">

This pull request adds a flag that is toggled to true when the IterableInboxMessageDisplay component is mounted. A useEffect cleanup function is added to toggle the flag to false when the component is unmounted.

see the following reference => [Here](https://www.debuggr.io/react-update-unmounted-component/)

[MOB-3735]: https://iterable.atlassian.net/browse/MOB-3735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ