### PR TITLE
[MOB-3864] update slider height with customization and custom layout

### DIFF
--- a/ts/IterableInboxMessageCell.tsx
+++ b/ts/IterableInboxMessageCell.tsx
@@ -166,6 +166,12 @@ const IterableInboxMessageCell = ({
 }: MessageCellProps) => {
    const position = useRef(new Animated.ValueXY()).current
 
+   let deleteSliderHeight = customizations.messageRow?.height ? customizations.messageRow.height: 120
+   
+   if(messageListItemLayout(last, rowViewModel)) {
+      deleteSliderHeight = messageListItemLayout(last, rowViewModel)[1]
+   }
+
    const styles = StyleSheet.create({
       textContainer: {
          width: '100%',
@@ -181,7 +187,7 @@ const IterableInboxMessageCell = ({
          position: 'absolute',
          elevation: 1,
          width: '100%',
-         height: customizations.messageRow?.height ? customizations.messageRow.height : 120
+         height: deleteSliderHeight
       },
    
       textStyle: {
@@ -269,7 +275,7 @@ const IterableInboxMessageCell = ({
                }}
             >
                {messageListItemLayout(last, rowViewModel) ? 
-                  messageListItemLayout(last, rowViewModel) : 
+                  messageListItemLayout(last, rowViewModel)[0] : 
                   defaultMessageListLayout(last, dataModel, rowViewModel, customizations, isPortrait)}
             </TouchableOpacity>
          </Animated.View>

--- a/ts/IterableInboxMessageCell.tsx
+++ b/ts/IterableInboxMessageCell.tsx
@@ -166,6 +166,31 @@ const IterableInboxMessageCell = ({
 }: MessageCellProps) => {
    const position = useRef(new Animated.ValueXY()).current
 
+   const styles = StyleSheet.create({
+      textContainer: {
+         width: '100%',
+         elevation: 2
+      },
+   
+      deleteSlider: {
+         flexDirection: 'row',
+         alignItems: 'center',
+         justifyContent: 'flex-end',
+         paddingRight: 10,
+         backgroundColor: 'red',
+         position: 'absolute',
+         elevation: 1,
+         width: '100%',
+         height: customizations.messageRow?.height ? customizations.messageRow.height : 120
+      },
+   
+      textStyle: {
+         fontWeight: 'bold',
+         fontSize: 15,
+         color: 'white'
+      }
+   })
+
    let { textContainer, deleteSlider, textStyle } = styles
 
    deleteSlider = (isPortrait) ? deleteSlider : { ...deleteSlider, paddingRight: 40 }
@@ -252,29 +277,6 @@ const IterableInboxMessageCell = ({
    )
 }
 
-const styles = StyleSheet.create({
-   textContainer: {
-      width: '100%',
-      elevation: 2
-   },
 
-   deleteSlider: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-end',
-      paddingRight: 10,
-      backgroundColor: 'red',
-      position: 'absolute',
-      elevation: 1,
-      width: '100%',
-      height: 120
-   },
-
-   textStyle: {
-      fontWeight: 'bold',
-      fontSize: 15,
-      color: 'white'
-   }
-})
 
 export default IterableInboxMessageCell


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3864] (https://iterable.atlassian.net/browse/MOB-3864)

## ✏️ Description

This pull request includes a small change that allows the delete slider to match the message row height when the styling customized. If the default inbox component is used, the delete slider has a default height. Also, I passed the message row height from the custom layout as a return value that is used by the IterableInboxMessageCell component.


[MOB-3864]: https://iterable.atlassian.net/browse/MOB-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ