### PR TITLE
[MOB-3910] null clicked url for triggered events

### DIFF
--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -98,7 +98,7 @@ const IterableInboxMessageDisplay = ({
       }
       
       if(URL === 'iterable://dismiss') {
-         Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link)
+         Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link, URL)
          returnToInbox()
          return
       }
@@ -107,7 +107,7 @@ const IterableInboxMessageDisplay = ({
          Linking.openURL(URL)
       }
 
-      Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link) 
+      Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link, URL) 
 
       if(Iterable.savedConfig.urlHandler) {
          Iterable.savedConfig.urlHandler(URL, context)


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3910] (https://iterable.atlassian.net/browse/MOB-3910)

## ✏️ Description

This pull request includes adding the clicked url to the trackInAppClose function call.


[MOB-3910]: https://iterable.atlassian.net/browse/MOB-3910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ