### PR TITLE
[MOB-3932] addresses invalid date on android

### DIFF
--- a/ts/IterableInAppMessage.ts
+++ b/ts/IterableInAppMessage.ts
@@ -111,10 +111,12 @@ class IterableInAppMessage {
     const campaignId = dict["campaignId"] as number
     const trigger = IterableInAppTrigger.fromDict(dict["trigger"])
     let createdAt = dict["createdAt"]
+    console.log("from Dict 1 - ", createdAt)
     if (createdAt) {
       var dateObject = new Date(0)
       createdAt = dateObject.setUTCMilliseconds(createdAt)
     }
+    console.log("from Dict 2 - ", createdAt)
     let expiresAt = dict["expiresAt"]
     if (expiresAt) {
       var dateObject = new Date(0)

--- a/ts/IterableInAppMessage.ts
+++ b/ts/IterableInAppMessage.ts
@@ -111,12 +111,10 @@ class IterableInAppMessage {
     const campaignId = dict["campaignId"] as number
     const trigger = IterableInAppTrigger.fromDict(dict["trigger"])
     let createdAt = dict["createdAt"]
-    console.log("from Dict 1 - ", createdAt)
     if (createdAt) {
       var dateObject = new Date(0)
       createdAt = dateObject.setUTCMilliseconds(createdAt)
     }
-    console.log("from Dict 2 - ", createdAt)
     let expiresAt = dict["expiresAt"]
     if (expiresAt) {
       var dateObject = new Date(0)

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -180,6 +180,7 @@ const IterableInbox = ({
             <IterableInboxMessageDisplay
                rowViewModel={selectedRowViewModel}
                inAppContentPromise={getHtmlContentForRow(selectedRowViewModel.inAppMessage.messageId)}
+               inboxDataModel={inboxDataModel}
                returnToInbox={() => returnToInbox()}
                deleteRow={(messageId: string) => deleteRow(messageId)}
                contentWidth={width}

--- a/ts/IterableInboxDataModel.ts
+++ b/ts/IterableInboxDataModel.ts
@@ -106,9 +106,18 @@ class IterableInboxDataModel {
             return ""
         }
 
-        const createdAt = new Date(message.createdAt)
+        let createdAt
 
-        var defaultDateString = `${createdAt.toLocaleDateString()} at ${createdAt.toLocaleTimeString()}`
+        if(typeof message.createdAt === "string") {
+            createdAt = new Date(parseInt(message.createdAt))
+        } else {
+            createdAt = new Date(message.createdAt)
+        }
+
+        console.log("Debug created at (type) - ", typeof message.createdAt)
+        console.log("Debug created at Date - ", createdAt)
+
+        var defaultDateString = `${createdAt.toLocaleDateString('en-US')} at ${createdAt.toLocaleTimeString('en-US')}`
 
         return defaultDateString
     }

--- a/ts/IterableInboxDataModel.ts
+++ b/ts/IterableInboxDataModel.ts
@@ -114,9 +114,6 @@ class IterableInboxDataModel {
             createdAt = new Date(message.createdAt)
         }
 
-        console.log("Debug created at (type) - ", typeof message.createdAt)
-        console.log("Debug created at Date - ", createdAt)
-
         var defaultDateString = `${createdAt.toLocaleDateString('en-US')} at ${createdAt.toLocaleTimeString('en-US')}`
 
         return defaultDateString

--- a/ts/IterableInboxDataModel.ts
+++ b/ts/IterableInboxDataModel.ts
@@ -114,7 +114,51 @@ class IterableInboxDataModel {
             createdAt = new Date(message.createdAt)
         }
 
-        var defaultDateString = `${createdAt.toLocaleDateString('en-US')} at ${createdAt.toLocaleTimeString('en-US')}`
+        let hour = createdAt.getHours() > 12 ? createdAt.getHours() - 12 : createdAt.getHours()
+        let AMPM = createdAt.getHours() > 12 ? 'PM' : 'AM'
+        let monthStr
+        switch (createdAt.getMonth()) {
+            case 0:
+                monthStr = 'Jan'
+                break
+            case 1:
+                monthStr = 'Feb'
+                break  
+            case 2:
+                monthStr = 'Mar';
+                break
+            case 3:
+                monthStr = 'Apr';
+                break
+            case 4:
+                monthStr = 'May'
+                break
+            case 5:
+                monthStr = 'Jun';
+                break
+            case 6:
+                monthStr = 'Jul';
+                break
+            case 7:
+                monthStr = 'Aug';
+                break
+            case 8:
+                monthStr = 'Sep';
+                break
+            case 9:
+                monthStr = 'Oct';
+                break
+            case 10:
+                monthStr = 'Nov';
+                break
+            case 11:
+                monthStr = 'Dec';
+                break
+            default:
+                console.log('Invalid Month');
+        }
+          
+        let defaultDateString = `${monthStr} ${createdAt.getDay()}, ${createdAt.getFullYear()} at ${hour}:${createdAt.getMinutes()} ${AMPM}}`
 
         return defaultDateString
     }

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -24,10 +24,12 @@ import {
    IterableActionSource,
    Iterable 
 } from '.' 
+import IterableInboxDataModel from './IterableInboxDataModel'
 
 type MessageDisplayProps = {
    rowViewModel: InboxRowViewModel,
    inAppContentPromise: Promise<IterableHtmlInAppContent>,
+   inboxDataModel: IterableInboxDataModel,
    returnToInbox: Function,
    deleteRow: Function,
    contentWidth: number,
@@ -36,7 +38,8 @@ type MessageDisplayProps = {
 
 const IterableInboxMessageDisplay = ({ 
    rowViewModel, 
-   inAppContentPromise, 
+   inAppContentPromise,
+   inboxDataModel, 
    returnToInbox,
    deleteRow, 
    contentWidth,
@@ -98,6 +101,7 @@ const IterableInboxMessageDisplay = ({
       }
       
       if(URL === 'iterable://dismiss') {
+         inboxDataModel.endSession()
          Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link)
          returnToInbox()
          return
@@ -107,6 +111,7 @@ const IterableInboxMessageDisplay = ({
          Linking.openURL(URL)
       }
 
+      inboxDataModel.endSession()
       Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link) 
 
       if(Iterable.savedConfig.urlHandler) {


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-3932] (https://iterable.atlassian.net/browse/MOB-3932)

## ✏️ Description

This pull request addresses the invalid date on the android side. I added a conversion of the createdAt value to a number when sent from the android SDK. Also, the formatting is updated to match the iOS native inbox. The former use of .toLocaleTimeString() was not working for the android side.


[MOB-3932]: https://iterable.atlassian.net/browse/MOB-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ