### PR TITLE
[MOB-4037] adds delay to deleteRow call to allow message display to be dismissed

### DIFF
--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -8,7 +8,8 @@ import {
    Animated,
    NativeModules,
    NativeEventEmitter,
-   Platform
+   Platform,
+   Linking
 } from 'react-native'
 
 import {
@@ -18,6 +19,7 @@ import {
    IterableInAppDeleteSource,
    IterableInAppLocation,
    IterableInboxEmptyState,
+   IterableActionContext,
    InboxImpressionRowInfo
 } from '.'
 
@@ -165,8 +167,13 @@ const IterableInbox = ({
       fetchInboxMessages()
    }
 
-   function returnToInbox() {
-      reset()
+   function returnToInbox(callback: Function) {
+      Animated.timing(animatedValue, {
+         toValue: 0,
+         duration: 500,
+         useNativeDriver: false
+      }).start(() => callback())
+      setIsMessageDisplay(false)
    }
 
    function updateVisibleMessageImpressions(messageImpressions: InboxImpressionRowInfo[]) {
@@ -181,7 +188,10 @@ const IterableInbox = ({
             <IterableInboxMessageDisplay
                rowViewModel={selectedRowViewModel}
                inAppContentPromise={getHtmlContentForRow(selectedRowViewModel.inAppMessage.messageId)}
-               returnToInbox={() => returnToInbox()}
+               returnToInbox={(callback: Function) => returnToInbox(callback)}
+               //returnToInboxDelete={(messageId: string) => returnToInboxDelete(messageId)}
+               //returnToInboxExternalLink={(URL: string) => returnToInboxExternalLink(URL)}
+               //returnToInboxInternalLink={(URL: string, context: IterableActionContext) => returnToInboxInternalLink(URL, context)}
                deleteRow={(messageId: string) => deleteRow(messageId)}
                contentWidth={width}
                isPortrait={isPortrait}
@@ -235,12 +245,12 @@ const IterableInbox = ({
       setIsMessageDisplay(true)
    }
 
-   function reset() {
+   function reset(callback: Function) {
       Animated.timing(animatedValue, {
          toValue: 0,
          duration: 500,
          useNativeDriver: false
-      }).start()
+      }).start(() => callback())
       setIsMessageDisplay(false)
    }
 

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -240,15 +240,6 @@ const IterableInbox = ({
       setIsMessageDisplay(true)
    }
 
-   function reset(callback: Function) {
-      Animated.timing(animatedValue, {
-         toValue: 0,
-         duration: 500,
-         useNativeDriver: false
-      }).start(() => callback())
-      setIsMessageDisplay(false)
-   }
-
    return(
       <View style={updatedContainer}>
          <Animated.View

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -165,12 +165,12 @@ const IterableInbox = ({
       fetchInboxMessages()
    }
 
-   function returnToInbox(callback: Function) {
+   function returnToInbox(callback?: Function) {
       Animated.timing(animatedValue, {
          toValue: 0,
          duration: 300,
          useNativeDriver: false
-      }).start(() => callback())
+      }).start(() => typeof callback === 'function' && callback())
       setIsMessageDisplay(false)
    }
 

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -187,9 +187,6 @@ const IterableInbox = ({
                rowViewModel={selectedRowViewModel}
                inAppContentPromise={getHtmlContentForRow(selectedRowViewModel.inAppMessage.messageId)}
                returnToInbox={(callback: Function) => returnToInbox(callback)}
-               //returnToInboxDelete={(messageId: string) => returnToInboxDelete(messageId)}
-               //returnToInboxExternalLink={(URL: string) => returnToInboxExternalLink(URL)}
-               //returnToInboxInternalLink={(URL: string, context: IterableActionContext) => returnToInboxInternalLink(URL, context)}
                deleteRow={(messageId: string) => deleteRow(messageId)}
                contentWidth={width}
                isPortrait={isPortrait}

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -168,7 +168,7 @@ const IterableInbox = ({
    function returnToInbox(callback: Function) {
       Animated.timing(animatedValue, {
          toValue: 0,
-         duration: 300,
+         duration: 500,
          useNativeDriver: false
       }).start(() => callback())
       setIsMessageDisplay(false)
@@ -234,7 +234,7 @@ const IterableInbox = ({
    function slideLeft() {
       Animated.timing(animatedValue, {
          toValue: 1,
-         duration: 300,
+         duration: 500,
          useNativeDriver: false
       }).start()
       setIsMessageDisplay(true)

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -8,8 +8,7 @@ import {
    Animated,
    NativeModules,
    NativeEventEmitter,
-   Platform,
-   Linking
+   Platform
 } from 'react-native'
 
 import {
@@ -19,7 +18,6 @@ import {
    IterableInAppDeleteSource,
    IterableInAppLocation,
    IterableInboxEmptyState,
-   IterableActionContext,
    InboxImpressionRowInfo
 } from '.'
 

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -168,7 +168,7 @@ const IterableInbox = ({
    function returnToInbox(callback: Function) {
       Animated.timing(animatedValue, {
          toValue: 0,
-         duration: 500,
+         duration: 300,
          useNativeDriver: false
       }).start(() => callback())
       setIsMessageDisplay(false)
@@ -234,7 +234,7 @@ const IterableInbox = ({
    function slideLeft() {
       Animated.timing(animatedValue, {
          toValue: 1,
-         duration: 500,
+         duration: 300,
          useNativeDriver: false
       }).start()
       setIsMessageDisplay(true)

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -34,6 +34,7 @@ const RNIterableAPI = NativeModules.RNIterableAPI
 const RNEventEmitter = new NativeEventEmitter(RNIterableAPI)
 
 type inboxProps = {
+   returnToInboxTrigger: boolean,
    messageListItemLayout?: Function,
    customizations?: IterableInboxCustomizations,
    tabBarHeight?: number,
@@ -41,6 +42,7 @@ type inboxProps = {
 }
 
 const IterableInbox = ({
+   returnToInboxTrigger,
    messageListItemLayout = () => { return null },
    customizations = {} as IterableInboxCustomizations,
    tabBarHeight = 80,
@@ -117,6 +119,12 @@ const IterableInbox = ({
    useEffect(() => {
       inboxDataModel.updateVisibleRows(visibleMessageImpressions)
    }, [visibleMessageImpressions])
+
+   useEffect(() => {
+      if(isMessageDisplay) {
+         returnToInbox()
+      }
+   }, [returnToInboxTrigger])
 
    function addInboxChangedListener() {
       RNEventEmitter.addListener(

--- a/ts/IterableInboxCustomizations.ts
+++ b/ts/IterableInboxCustomizations.ts
@@ -1,69 +1,69 @@
 type IterableInboxCustomizations = {
-   navTitle: string,
-   noMessagesTitle: string,
-   noMessagesBody: string,
+   navTitle?: string,
+   noMessagesTitle?: string,
+   noMessagesBody?: string,
 
-   unreadIndicatorContainer: {
-      flexDirection: string,
-      justifyContent: string
+   unreadIndicatorContainer?: {
+      flexDirection?: string,
+      justifyContent?: string
    },
 
-   unreadIndicator: {
-      width: number,
-      height: number,
-      borderRadius: number,
-      backgroundColor: string,
-      marginLeft: number,
-      marginRight: number,
-      marginTop: number
+   unreadIndicator?: {
+      width?: number,
+      height?: number,
+      borderRadius?: number,
+      backgroundColor?: string,
+      marginLeft?: number,
+      marginRight?: number,
+      marginTop?: number
    },
 
-   unreadMessageIconContainer: {
-      paddingLeft: number,
-      flexDirection: string,
-      justifyContent: string
+   unreadMessageIconContainer?: {
+      paddingLeft?: number,
+      flexDirection?: string,
+      justifyContent?: string
    },
 
-   readMessageIconContainer: {
-      paddingLeft: number,
-      flexDirection: string,
-      justifyContent: string
+   readMessageIconContainer?: {
+      paddingLeft?: number,
+      flexDirection?: string,
+      justifyContent?: string
    },
 
-   messageContainer: {
-      paddingLeft: number,
-      width: string,
-      flexDirection: string,
-      justifyContent: string
+   messageContainer?: {
+      paddingLeft?: number,
+      width?: string,
+      flexDirection?: string,
+      justifyContent?: string
    },
 
-   title: {
-      fontSize: number,
-      paddingBottom: number
+   title?: {
+      fontSize?: number,
+      paddingBottom?: number
    },
 
-   body: {
-      fontSize: number,
-      color: string,
-      width: string,
-      flexWrap: string,
-      paddingBottom: number
+   body?: {
+      fontSize?: number,
+      color?: string,
+      width?: string,
+      flexWrap?: string,
+      paddingBottom?: number
    },
 
-   createdAt: {
-      fontSize: number,
-      color: string
+   createdAt?: {
+      fontSize?: number,
+      color?: string
    },
 
-   messageRow: {
-      flexDirection: string,
-      backgroundColor: string,
-      paddingTop: number,
-      paddingBottom: number,
-      height: number,
-      borderStyle: string,
-      borderColor: string,
-      borderTopWidth: number
+   messageRow?: {
+      flexDirection?: string,
+      backgroundColor?: string,
+      paddingTop?: number,
+      paddingBottom?: number,
+      height?: number,
+      borderStyle?: string,
+      borderColor?: string,
+      borderTopWidth?: number
    }
 }
 

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -114,7 +114,7 @@ const IterableInboxMessageDisplay = ({
          <View style={returnButtonContainer}>
             <TouchableWithoutFeedback 
                onPress={() => {
-                  returnToInbox()
+                  returnToInbox(() => {})
                   Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.back)
                }}>
                <Icon

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -29,6 +29,9 @@ type MessageDisplayProps = {
    rowViewModel: InboxRowViewModel,
    inAppContentPromise: Promise<IterableHtmlInAppContent>,
    returnToInbox: Function,
+   //returnToInboxDelete: Function,
+   //returnToInboxExternalLink: Function,
+   //returnToInboxInternalLink: Function,
    deleteRow: Function,
    contentWidth: number,
    isPortrait: boolean
@@ -38,6 +41,9 @@ const IterableInboxMessageDisplay = ({
    rowViewModel, 
    inAppContentPromise, 
    returnToInbox,
+   //returnToInboxDelete,
+   //returnToInboxExternalLink,
+   //returnToInboxInternalLink,
    deleteRow, 
    contentWidth,
    isPortrait
@@ -92,30 +98,21 @@ const IterableInboxMessageDisplay = ({
       let context = new IterableActionContext(action, source)
 
       Iterable.trackInAppClick(rowViewModel.inAppMessage, IterableInAppLocation.inbox, URL)
-
-      if (URL === 'iterable://delete') {
-         setTimeout(() => {
-            deleteRow(rowViewModel.inAppMessage.messageId)
-         }, 500)
-      }
-      
-      if(URL === 'iterable://dismiss') {
-         Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link, URL)
-         returnToInbox()
-         return
-      }
-
-      if (URL.slice(0, 4) === 'http') {
-         Linking.openURL(URL)
-      }
-
       Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.link, URL) 
 
-      if(Iterable.savedConfig.urlHandler) {
-         Iterable.savedConfig.urlHandler(URL, context)
+      if (URL === 'iterable://delete') { 
+         returnToInbox(() => deleteRow(rowViewModel.inAppMessage.messageId))
+      } else if(URL === 'iterable://dismiss') {
+         returnToInbox(() => {})
+      } else if (URL.slice(0, 4) === 'http') {
+         returnToInbox(() => Linking.openURL(URL))
+      } else {
+         returnToInbox(() => {
+            if(Iterable.savedConfig.urlHandler) {
+               Iterable.savedConfig.urlHandler(URL, context)
+            } 
+         })
       }
-      
-      returnToInbox()
    }
 
    return (

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -29,9 +29,6 @@ type MessageDisplayProps = {
    rowViewModel: InboxRowViewModel,
    inAppContentPromise: Promise<IterableHtmlInAppContent>,
    returnToInbox: Function,
-   //returnToInboxDelete: Function,
-   //returnToInboxExternalLink: Function,
-   //returnToInboxInternalLink: Function,
    deleteRow: Function,
    contentWidth: number,
    isPortrait: boolean
@@ -41,9 +38,6 @@ const IterableInboxMessageDisplay = ({
    rowViewModel, 
    inAppContentPromise, 
    returnToInbox,
-   //returnToInboxDelete,
-   //returnToInboxExternalLink,
-   //returnToInboxInternalLink,
    deleteRow, 
    contentWidth,
    isPortrait

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -94,7 +94,9 @@ const IterableInboxMessageDisplay = ({
       Iterable.trackInAppClick(rowViewModel.inAppMessage, IterableInAppLocation.inbox, URL)
 
       if (URL === 'iterable://delete') {
-         deleteRow(rowViewModel.inAppMessage.messageId)
+         setTimeout(() => {
+            deleteRow(rowViewModel.inAppMessage.messageId)
+         }, 500)
       }
       
       if(URL === 'iterable://dismiss') {

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -84,7 +84,7 @@ const IterableInboxMessageDisplay = ({
       return () => {mounted = false}
    })
 
-   function handleHTMLMessage(event: any) {
+   function handleInAppLinkAction(event: any) {
       let URL = event.nativeEvent.data
 
       let action = new IterableAction("openUrl", URL, "")
@@ -130,7 +130,7 @@ const IterableInboxMessageDisplay = ({
                originWhiteList={['*']}
                source={{ html: inAppContent.html }}
                style={{ width: contentWidth }}
-               onMessage={(event) => handleHTMLMessage(event)}
+               onMessage={(event) => handleInAppLinkAction(event)}
                injectedJavaScript={JS}
             />
          </ScrollView>

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -97,7 +97,7 @@ const IterableInboxMessageDisplay = ({
       if (URL === 'iterable://delete') { 
          returnToInbox(() => deleteRow(rowViewModel.inAppMessage.messageId))
       } else if(URL === 'iterable://dismiss') {
-         returnToInbox(() => {})
+         returnToInbox()
       } else if (URL.slice(0, 4) === 'http') {
          returnToInbox(() => Linking.openURL(URL))
       } else {
@@ -114,7 +114,7 @@ const IterableInboxMessageDisplay = ({
          <View style={returnButtonContainer}>
             <TouchableWithoutFeedback 
                onPress={() => {
-                  returnToInbox(() => {})
+                  returnToInbox()
                   Iterable.trackInAppClose(rowViewModel.inAppMessage, IterableInAppLocation.inbox, IterableInAppCloseSource.back)
                }}>
                <Icon


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4037] (https://iterable.atlassian.net/browse/MOB-4037)

## ✏️ Description

This pull request updates the return to inbox functionality, so that for all actions involving returning to the inbox the animation completes first. For example, when a user selects the delete button, the message display closes first before the message is deleted.


[MOB-4037]: https://iterable.atlassian.net/browse/MOB-4037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ