### PR TITLE
[MOB-4321] increases default delete slider height

### DIFF
--- a/ts/IterableInboxMessageCell.tsx
+++ b/ts/IterableInboxMessageCell.tsx
@@ -168,7 +168,7 @@ const IterableInboxMessageCell = ({
 }: MessageCellProps) => {
    const position = useRef(new Animated.ValueXY()).current
 
-   let deleteSliderHeight = customizations.messageRow?.height ? customizations.messageRow.height: 120
+   let deleteSliderHeight = customizations.messageRow?.height ? customizations.messageRow.height: 150
    
    if(messageListItemLayout(last, rowViewModel)) {
       deleteSliderHeight = messageListItemLayout(last, rowViewModel)[1]


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4321] (https://iterable.atlassian.net/browse/MOB-4321)

## ✏️ Description

This pull request increases the default delete slider height to 150 to account for increasing the number of lines in the message cell body to 3.


[MOB-4321]: https://iterable.atlassian.net/browse/MOB-4321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ