### PR TITLE
[MOB-4336] sets the returnToInboxTrigger as an optional parameter

### DIFF
--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -36,7 +36,7 @@ const RNIterableAPI = NativeModules.RNIterableAPI
 const RNEventEmitter = new NativeEventEmitter(RNIterableAPI)
 
 type inboxProps = {
-   returnToInboxTrigger: boolean,
+   returnToInboxTrigger?: boolean,
    messageListItemLayout?: Function,
    customizations?: IterableInboxCustomizations,
    tabBarHeight?: number,
@@ -44,7 +44,7 @@ type inboxProps = {
 }
 
 const IterableInbox = ({
-   returnToInboxTrigger,
+   returnToInboxTrigger = true,
    messageListItemLayout = () => { return null },
    customizations = {} as IterableInboxCustomizations,
    tabBarHeight = 80,


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4336] (https://iterable.atlassian.net/browse/MOB-4336)

## ✏️ Description

This pull request sets the returnToInboxTrigger as an optional parameter to the inbox component.


[MOB-4336]: https://iterable.atlassian.net/browse/MOB-4336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ