### PR TITLE
[MOB-4337] reorganizes the rendering of the inbox for button vs. tab

### DIFF
--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -283,10 +283,9 @@ const IterableInbox = ({
       setIsMessageDisplay(true)
    }
 
-   function renderMessageDisplaySlider() {
-      return(
-         <Animated.View
-            style={{
+   const messageDisplaySlider =
+      <Animated.View
+         style={{
                transform: [
                   {
                      translateX: animatedValue.interpolate({
@@ -303,14 +302,12 @@ const IterableInbox = ({
          >
             {showMessageList(loading)}
             {showMessageDisplay(rowViewModels, selectedRowViewModelIdx)}
-         </Animated.View>
-      )
-   }
+      </Animated.View>
 
    return(
       (safeAreaMode) ?
-         <SafeAreaView style={container}>{renderMessageDisplaySlider()}</SafeAreaView> : 
-         <View style={container}>{renderMessageDisplaySlider()}</View> 
+         <SafeAreaView style={container}>{messageDisplaySlider}</SafeAreaView> : 
+         <View style={container}>{messageDisplaySlider}</View> 
    )
 }
 

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -283,7 +283,7 @@ const IterableInbox = ({
       setIsMessageDisplay(true)
    }
 
-   const messageDisplaySlider =
+   const inboxAnimatedView =
       <Animated.View
          style={{
                transform: [
@@ -306,8 +306,8 @@ const IterableInbox = ({
 
    return(
       (safeAreaMode) ?
-         <SafeAreaView style={container}>{messageDisplaySlider}</SafeAreaView> : 
-         <View style={container}>{messageDisplaySlider}</View> 
+         <SafeAreaView style={container}>{inboxAnimatedView}</SafeAreaView> : 
+         <View style={container}>{inboxAnimatedView}</View> 
    )
 }
 

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -40,7 +40,8 @@ type inboxProps = {
    messageListItemLayout?: Function,
    customizations?: IterableInboxCustomizations,
    tabBarHeight?: number,
-   tabBarPadding?: number
+   tabBarPadding?: number,
+   inboxMode?: string
 }
 
 const IterableInbox = ({
@@ -48,7 +49,8 @@ const IterableInbox = ({
    messageListItemLayout = () => { return null },
    customizations = {} as IterableInboxCustomizations,
    tabBarHeight = 80,
-   tabBarPadding = 20
+   tabBarPadding = 20,
+   inboxMode = "tab"
 }: inboxProps) => {
    const defaultInboxTitle = "Inbox"
    const inboxDataModel = new IterableInboxDataModel()
@@ -112,6 +114,7 @@ const IterableInbox = ({
 
    const navTitleHeight = headline.height + headline.paddingTop + headline.paddingBottom
    headline = { ...headline, height: Platform.OS === "android" ? 70 : 60 }
+   headline = (!isPortrait) ? { ...headline, paddingLeft: 70 } : headline
 
    useEffect(() => {
       fetchInboxMessages()
@@ -280,8 +283,8 @@ const IterableInbox = ({
       setIsMessageDisplay(true)
    }
 
-   return(
-      <SafeAreaView style={container}>
+   function renderMessageDisplaySlider() {
+      return(
          <Animated.View
             style={{
                transform: [
@@ -301,7 +304,13 @@ const IterableInbox = ({
             {showMessageList(loading)}
             {showMessageDisplay(rowViewModels, selectedRowViewModelIdx)}
          </Animated.View>
-      </SafeAreaView>
+      )
+   }
+
+   return(
+      (inboxMode === "button") ? 
+         <View style={container}>{renderMessageDisplaySlider()}</View> :
+         <SafeAreaView style={container}>{renderMessageDisplaySlider()}</SafeAreaView> 
    )
 }
 

--- a/ts/IterableInbox.tsx
+++ b/ts/IterableInbox.tsx
@@ -41,7 +41,7 @@ type inboxProps = {
    customizations?: IterableInboxCustomizations,
    tabBarHeight?: number,
    tabBarPadding?: number,
-   inboxMode?: string
+   safeAreaMode?: boolean
 }
 
 const IterableInbox = ({
@@ -50,7 +50,7 @@ const IterableInbox = ({
    customizations = {} as IterableInboxCustomizations,
    tabBarHeight = 80,
    tabBarPadding = 20,
-   inboxMode = "tab"
+   safeAreaMode = true
 }: inboxProps) => {
    const defaultInboxTitle = "Inbox"
    const inboxDataModel = new IterableInboxDataModel()
@@ -308,9 +308,9 @@ const IterableInbox = ({
    }
 
    return(
-      (inboxMode === "button") ? 
-         <View style={container}>{renderMessageDisplaySlider()}</View> :
-         <SafeAreaView style={container}>{renderMessageDisplaySlider()}</SafeAreaView> 
+      (safeAreaMode) ?
+         <SafeAreaView style={container}>{renderMessageDisplaySlider()}</SafeAreaView> : 
+         <View style={container}>{renderMessageDisplaySlider()}</View> 
    )
 }
 

--- a/ts/IterableInboxMessageDisplay.tsx
+++ b/ts/IterableInboxMessageDisplay.tsx
@@ -123,7 +123,7 @@ const IterableInboxMessageDisplay = ({
    } = styles
 
    // orientation dependent styling
-   returnButtonContainer = (!isPortrait) ? { ...returnButtonContainer, marginLeft: 40 } : returnButtonContainer
+   returnButtonContainer = (!isPortrait) ? { ...returnButtonContainer, marginLeft: 80 } : returnButtonContainer
 
    let JS = `
       const links = document.querySelectorAll('a')


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4337] (https://iterable.atlassian.net/browse/MOB-4337)

## ✏️ Description

This pull request reorganizes the rendering of the inbox component as a button vs. as a navigation tab. When the inbox is set up as a button, the inbox is rendered within a view rather than a safe area view.


[MOB-4337]: https://iterable.atlassian.net/browse/MOB-4337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ