### PR TITLE
ready: Add missing Iterable and IterableConfig exports back to index.ts

### DIFF
--- a/ts/__tests__/Iterable.spec.ts
+++ b/ts/__tests__/Iterable.spec.ts
@@ -3,8 +3,13 @@ import { MockLinking } from '../__mocks__/MockLinking'
 import { TestHelper } from './TestHelper'
 import { NativeEventEmitter } from 'react-native'
 
+// import from the same location that consumers import from
 import {
   Iterable,
+  IterableConfig
+} from '../index'
+
+import {
   IterableAttributionInfo,
   IterableCommerceItem,
   IterableActionContext,
@@ -12,8 +17,6 @@ import {
   IterableAction,
   IterableActionSource
 } from '../Iterable'
-
-import IterableConfig from '../IterableConfig'
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -5,6 +5,8 @@
 * @module react-native-iterable-sdk
 */
 
+import { Iterable } from './Iterable'
+
 import { 
   IterableAction, 
   IterableActionContext, 
@@ -34,7 +36,11 @@ import useAppStateListener from './useAppStateListener'
 import useDeviceOrientation from './useDeviceOrientation'
 import InboxImpressionRowInfo from './InboxImpressionRowInfo'
 
+import IterableConfig from './IterableConfig'
+
 export {
+  Iterable,
+  IterableConfig,
   IterableAction,
   IterableActionContext,
   IterableLogLevel,


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

No tickets - PR is to address this issue https://github.com/Iterable/react-native-sdk/issues/356

## ✏️ Description

After the 1.3.1 release, `Iterable` and `IterableConfig` were no longer exported from index.ts. This PR adds them back in. I've also made the unit tests import from index.ts rather than the implementation files, as consumers will be importing from index (so if this happens again, it will be caught by unit tests in CI).

---

If these removals were intentional and there's a new way to import these classes from the SDK, feel free to close out this PR. Documentation would need to be updated in that case as found here: https://support.iterable.com/hc/en-us/articles/360045714132-Installing-Iterable-s-React-Native-SDK-#_5-import-classes-as-needed