### PR TITLE
fix gradle config to inherit values from parent project using safextget

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,16 @@ apply plugin: 'com.android.library'
 
 import groovy.json.JsonSlurper
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 28
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

N/A external

## ✏️ Description

> Please provide a brief description of what this pull request does.

Currently we are having to patch the plugin because the gradle build config is hardcoding values rather than inheriting them from the parent project. I applied the standard `safeExtGet` code popular in most gradle configs to inherit the parent values with a fallback. Otherwise user's projects will error out due to the hardcoding and users must patch the plugin to keep building.