### PR TITLE
[MOB-4692] - Override authHandler's new methods

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -588,6 +588,18 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         }
     }
 
+    @Override
+    public void onTokenRegistrationSuccessful(String authToken) {
+        IterableLogger.v(TAG, "authToken successfully set");
+        //TODO: Pass successhandler to event listener
+    }
+
+    @Override
+    public void onTokenRegistrationFailed(Throwable object) {
+        IterableLogger.v(TAG, "Failed to set authToken");
+        //TODO: Pass failureObject to event listener
+    }
+
     @ReactMethod
     public void addListener(String eventName) {
         // Keep: Required for RN built in Event Emitter Calls.


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4692](https://iterable.atlassian.net/browse/MOB-4692)

## ✏️ Description

Android SDK has added functionality to trigger onSuccess and onFailure callbacks.

Because RN SDK’s internal Java methods implement AuthHandler, it needs to implement the additional methods as well.

This will prevent any build errors also prepare for RN’s version of authHandler success and failure callbacks to be implemented next.
