### PR TITLE
[MOB-4917] add downstream support for the android SDK in memory option 

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/Serialization.java
+++ b/android/src/main/java/com/iterable/reactnative/Serialization.java
@@ -167,6 +167,10 @@ class Serialization {
                 configBuilder.setInAppDisplayInterval(iterableContextJSON.optDouble("inAppDisplayInterval"));
             }
 
+            if (iterableContextJSON.has("androidSdkUseInMemoryStorageForInApps")) {
+                configBuilder.setUseInMemoryStorageForInApps(iterableContextJSON.optBoolean("androidSdkUseInMemoryStorageForInApps"));
+            }
+
             if (iterableContextJSON.has("logLevel")) {
                 int logLevel = iterableContextJSON.getInt("logLevel");
                 switch (logLevel) {
@@ -186,6 +190,7 @@ class Serialization {
                         logLevel = Log.ERROR;
                         break;
                 }
+
                 configBuilder.setLogLevel(logLevel);
             }
 

--- a/ts/IterableConfig.ts
+++ b/ts/IterableConfig.ts
@@ -83,6 +83,12 @@ class IterableConfig {
   */
   allowedProtocols: Array<string> = []
 
+  /**
+   * This specifies the `useInMemoryStorageForInApps` config option downstream to the Android SDK layer.
+   * Please read the `IterableConfig` file for specific details on this config option.
+   */
+  androidSdkUseInMemoryStorageForInApps: boolean = false
+
   toDict(): any {
     return {
       "pushIntegrationName": this.pushIntegrationName,
@@ -94,7 +100,8 @@ class IterableConfig {
       "authHandlerPresent": this.authHandler != undefined,
       "logLevel": this.logLevel,
       "expiringAuthTokenRefreshPeriod": this.expiringAuthTokenRefreshPeriod,
-      "allowedProtocols": this.allowedProtocols
+      "allowedProtocols": this.allowedProtocols,
+      "androidSdkUseInMemoryStorageForInApps": this.androidSdkUseInMemoryStorageForInApps
     }
   }
 }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4917](https://iterable.atlassian.net/browse/MOB-4917)

## ✏️ Description

* allows RN SDK devs to configure the android SDK `useInMemoryStorageForInApps` config option
