### PR TITLE
Mob 4695 authhandler support for success and failure callbacks

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -592,12 +592,13 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     public void onTokenRegistrationSuccessful(String authToken) {
         IterableLogger.v(TAG, "authToken successfully set");
         //TODO: Pass successhandler to event listener
+        sendEvent(EventName.handleAuthSuccessCalled.name(), null);
     }
 
     @Override
     public void onTokenRegistrationFailed(Throwable object) {
         IterableLogger.v(TAG, "Failed to set authToken");
-        //TODO: Pass failureObject to event listener
+        sendEvent(EventName.handleAuthFailureCalled.name(), null);
     }
 
     @ReactMethod
@@ -643,5 +644,7 @@ enum EventName {
     handleCustomActionCalled,
     handleInAppCalled,
     handleAuthCalled,
-    receivedIterableInboxChanged
+    receivedIterableInboxChanged,
+    handleAuthSuccessCalled,
+    handleAuthFailureCalled
 }

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -33,6 +33,8 @@ class ReactIterableAPI: RCTEventEmitter {
         case handleInAppCalled
         case handleAuthCalled
         case receivedIterableInboxChanged
+        case handleAuthSuccessCalled
+        case handleAuthFailureCalled
     }
     
     override func supportedEvents() -> [String]! {
@@ -662,12 +664,18 @@ extension ReactIterableAPI: IterableAuthDelegate {
                 DispatchQueue.main.async {
                     completion(self.passedAuthToken)
                 }
+                
+                self.sendEvent(withName: EventName.handleAuthSuccessCalled.rawValue,
+                               body: nil)
             } else {
                 ITBInfo("authTokenRetrieval timed out")
                 
                 DispatchQueue.main.async {
                     completion(nil)
                 }
+                
+                self.sendEvent(withName: EventName.handleAuthFailureCalled.rawValue,
+                               body: nil)
             }
         }
     }

--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -469,20 +469,21 @@ class Iterable {
 
                 setTimeout(() => {
                   if(authResponseCallback === "success") {
-                    console.log('Gonna invoke success callback on ts');
-                    (promiseResult as AuthResponse).successCallback
+                    if((promiseResult as AuthResponse).successCallback){
+                      console.log('Gonna invoke success callback on ts');
+                      (promiseResult as AuthResponse).successCallback!()
+                    }
                   } else if(authResponseCallback === "failure") {
-                    console.log('Gonna invoke failure callback on ts');
-                    (promiseResult as AuthResponse).failureCallback
+                    if((promiseResult as AuthResponse).failureCallback){
+                      console.log('Gonna invoke failure callback on ts');
+                      (promiseResult as AuthResponse).failureCallback!()
+                    }
                   } else {
                     console.log('No callback received from native layer')
                   }
                 }, 1000)
-
-
-
               } else if (typeof promiseResult === typeof "") {
-                console.log(' In else if')
+                //If promise only returns string
                 RNIterableAPI.passAlongAuthToken((promiseResult as String))
               } else {
                 console.log('Unexpected promise returned. Auth token expects promise of String or AuthResponse type.')
@@ -494,14 +495,12 @@ class Iterable {
       RNEventEmitter.addListener(
         EventName.handleAuthSuccessCalled,
         () => {
-            // (promiseResult as AuthResponse).successCallback
           authResponseCallback = "success"
         }
       )
       RNEventEmitter.addListener(
         EventName.handleAuthFailureCalled,
         () => {
-          // (promiseResult as AuthResponse).failureCallback
           authResponseCallback = "failure"
         }
       )

--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -453,6 +453,7 @@ class Iterable {
     }
 
     if (Iterable.savedConfig.authHandler) {
+      var authResponseCallback = ""
       RNEventEmitter.addListener(
         EventName.handleAuthCalled,
         () => {
@@ -461,27 +462,47 @@ class Iterable {
             // Promise result can be either just String OR of type AuthResponse. 
             // If type AuthReponse, authToken will be parsed looking for `authToken` within promised object. Two additional listeners will be registered for success and failure callbacks sent by native bridge layer.
             // Else it will be looked for as a String.
-              if(typeof promiseResult == typeof AuthResponse) {
-                RNEventEmitter.addListener(
-                  EventName.handleAuthSuccessCalled,
-                  () => {
-                      (promiseResult as AuthResponse).successCallback
-                  }
-                )
-                RNEventEmitter.addListener(
-                  EventName.handleAuthFailureCalled,
-                  () => {
-                    (promiseResult as AuthResponse).failureCallback
-                  }
-                )
-
+            console.log("Promise Result type is " + typeof promiseResult + "... AuthReponse type is " + typeof (new AuthResponse()))
+              if(typeof promiseResult === typeof (new AuthResponse())) {
+               
                 RNIterableAPI.passAlongAuthToken((promiseResult as AuthResponse).authToken)
-              } else if (typeof promiseResult == typeof String) {
+
+                setTimeout(() => {
+                  if(authResponseCallback === "success") {
+                    console.log('Gonna invoke success callback on ts');
+                    (promiseResult as AuthResponse).successCallback
+                  } else if(authResponseCallback === "failure") {
+                    console.log('Gonna invoke failure callback on ts');
+                    (promiseResult as AuthResponse).failureCallback
+                  } else {
+                    console.log('No callback received from native layer')
+                  }
+                }, 1000)
+
+
+
+              } else if (typeof promiseResult === typeof "") {
+                console.log(' In else if')
                 RNIterableAPI.passAlongAuthToken((promiseResult as String))
               } else {
                 console.log('Unexpected promise returned. Auth token expects promise of String or AuthResponse type.')
               }
             }).catch(e => console.log(e))
+        }
+      )
+
+      RNEventEmitter.addListener(
+        EventName.handleAuthSuccessCalled,
+        () => {
+            // (promiseResult as AuthResponse).successCallback
+          authResponseCallback = "success"
+        }
+      )
+      RNEventEmitter.addListener(
+        EventName.handleAuthFailureCalled,
+        () => {
+          // (promiseResult as AuthResponse).failureCallback
+          authResponseCallback = "failure"
         }
       )
     }

--- a/ts/IterableConfig.ts
+++ b/ts/IterableConfig.ts
@@ -10,6 +10,9 @@ import { IterableInAppShowResponse } from './IterableInAppClasses'
 
 import IterableInAppMessage from './IterableInAppMessage'
 
+
+type AuthCallBack = (() => void)
+
 /**
 Iterable Configuration Object. Use this when initializing the API.
 */
@@ -57,8 +60,8 @@ class IterableConfig {
   /**
    * The handler with which your own calls to your backend containing the auth token happen
    */
-  authHandler?: () => Promise<string | undefined>
-
+  // authHandler?: (success?: AuthCallBack, failure?:  AuthCallBack) => Promise<AuthResponse | undefined>
+  authHandler?:() => Promise<AuthResponse | String | undefined>
   /**
    * Set the verbosity of Android and iOS project's log system. 
    * By default, you will be able to see info level logs printed in IDE when running the app. 
@@ -98,5 +101,11 @@ class IterableConfig {
     }
   }
 }
+
+export class AuthResponse {
+  authToken?: string = ""
+  successCallback?: AuthCallBack
+  failureCallback?: AuthCallBack
+} 
 
 export default IterableConfig


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-4695](https://iterable.atlassian.net/browse/MOB-4695)

## ✏️ Description

1. case handleAuthSuccessCalled and handleAuthFailureCalled added to both Android and iOS Native bridge.
2. If promise type is of type AuthResponse, we will look for string inside it and callbacks if present will be called after waiting for 1 second on Android. For iOS, semaphores is already implemented.
3. If promise if of type ""(string), code should work like before and no callbacks come into the scene.

TODO: Have to remove console log statements which are unnecessary

Verified the functionality of callbacks being called on Android and iOS.
