### PR TITLE
[MOB-5198] updates return types for getEmail and getUserId methods of MockRNIterableAPI

### DIFF
--- a/ts/__mocks__/MockRNIterableAPI.ts
+++ b/ts/__mocks__/MockRNIterableAPI.ts
@@ -7,7 +7,7 @@ export class MockRNIterableAPI {
   static lastPushPayload?: any
   static attributionInfo?: IterableAttributionInfo
 
-  static getEmail(): Promise<string> {
+  static getEmail(): Promise<string | undefined> {
     return new Promise((resolve, _) => {
       resolve(MockRNIterableAPI.email)
     })
@@ -18,7 +18,7 @@ export class MockRNIterableAPI {
     MockRNIterableAPI.token = authToken
   }
 
-  static getUserId(): Promise<string> {
+  static getUserId(): Promise<string | undefined> {
     return new Promise((resolve, _) => {
       resolve(MockRNIterableAPI.userId)
     })


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-5198](https://iterable.atlassian.net/browse/MOB-5198)

## ✏️ Description

This pull request updates the return types for the getEmail and getUSerId methods for the mock RNIterableAPI.

