### PR TITLE
[MOB-5252] refactors showMessage unit test

### DIFF
--- a/ts/__mocks__/MockRNIterableAPI.ts
+++ b/ts/__mocks__/MockRNIterableAPI.ts
@@ -1,4 +1,5 @@
 import { IterableAttributionInfo } from '../Iterable'
+import IterableInAppMessage from '../IterableInAppMessage'
 
 export class MockRNIterableAPI {
   static email?: string
@@ -6,6 +7,7 @@ export class MockRNIterableAPI {
   static token?: string
   static lastPushPayload?: any
   static attributionInfo?: IterableAttributionInfo
+  static clickedUrl?: string
 
   static getEmail(): Promise<string> {
     return new Promise((resolve, _) => {
@@ -69,7 +71,11 @@ export class MockRNIterableAPI {
 
   static setAutoDisplayPaused = jest.fn()
 
-  static showMessage = jest.fn()
+  static showMessage(message: IterableInAppMessage, consume: boolean): Promise<string | undefined> {
+    return new Promise((resolve, _) => {
+      resolve(MockRNIterableAPI.clickedUrl)
+    })
+  }
 
   static removeMessage = jest.fn()
 
@@ -84,5 +90,11 @@ export class MockRNIterableAPI {
   static handleAppLink = jest.fn()
 
   static updateSubscriptions = jest.fn()
+
+  // setClickedUrl function is to set the messages static property
+  // this is for testing purposes only
+  static setClickedUrl(clickedUrl: string) {
+    MockRNIterableAPI.clickedUrl = clickedUrl 
+  }
 }
 

--- a/ts/__tests__/IterableInApp.spec.ts
+++ b/ts/__tests__/IterableInApp.spec.ts
@@ -130,21 +130,23 @@ test("get in-app messages", () => {
   })
 })
 
-test("in-app show message is called", () => {
-  const messageDict = {
+test("showMessage_messageAndConsume_returnsClickedUrl", () => {
+  // GIVEN an in-app message and a clicked url
+  let messageDict = {
     "messageId": "message1",
     "campaignId": 1234,
     "trigger": { "type": IterableInAppTriggerType.immediate },
   }
-  const message = IterableInAppMessage.fromDict(messageDict)
-  MockRNIterableAPI.showMessage = jest.fn((message, consume) => {
-    return new Promise<void>(res => {
-      res()
-    })
-  })
+  let message: IterableInAppMessage = IterableInAppMessage.fromDict(messageDict)
+  let consume: boolean = true
+  let clickedUrl: string = "testUrl"
 
-  return Iterable.inAppManager.showMessage(message, true).then(_ => {
-    expect(MockRNIterableAPI.showMessage).toBeCalledWith(message.messageId, true)
+  // WHEN the simulated clicked url is set to the clicked url
+  MockRNIterableAPI.setClickedUrl(clickedUrl)
+
+  // THEN Iterable,inAppManager.showMessage returns the simulated clicked url
+  return Iterable.inAppManager.showMessage(message, consume).then(url => {
+    expect(url).toEqual(clickedUrl)
   })
 })
 


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-5252](https://iterable.atlassian.net/browse/MOB-5252)

## ✏️ Description

This pull request adds the clickedUrl static property and setter to the MockRNIterableAPI class for testing purposes. The showMessage unit test is refactored to test returning the set clicked url.
