### PR TITLE
[MOB-5245] refactor get messages unit test

### DIFF
--- a/ts/__mocks__/MockRNIterableAPI.ts
+++ b/ts/__mocks__/MockRNIterableAPI.ts
@@ -1,4 +1,3 @@
-import { resolvePlugin } from '@babel/core'
 import { IterableAttributionInfo } from '../Iterable'
 import IterableInAppMessage from '../IterableInAppMessage'
 

--- a/ts/__mocks__/MockRNIterableAPI.ts
+++ b/ts/__mocks__/MockRNIterableAPI.ts
@@ -1,4 +1,6 @@
+import { resolvePlugin } from '@babel/core'
 import { IterableAttributionInfo } from '../Iterable'
+import IterableInAppMessage from '../IterableInAppMessage'
 
 export class MockRNIterableAPI {
   static email?: string
@@ -6,6 +8,7 @@ export class MockRNIterableAPI {
   static token?: string
   static lastPushPayload?: any
   static attributionInfo?: IterableAttributionInfo
+  static messages?: IterableInAppMessage[]
 
   static getEmail(): Promise<string> {
     return new Promise((resolve, _) => {
@@ -65,7 +68,11 @@ export class MockRNIterableAPI {
 
   static setInAppShowResponse = jest.fn()
 
-  static getInAppMessages = jest.fn()
+  static getInAppMessages(): Promise<IterableInAppMessage[] | undefined> {
+    return new Promise((resolve, _) => {
+      resolve(MockRNIterableAPI.messages)
+    })
+  }
 
   static setAutoDisplayPaused = jest.fn()
 
@@ -84,5 +91,11 @@ export class MockRNIterableAPI {
   static handleAppLink = jest.fn()
 
   static updateSubscriptions = jest.fn()
+
+  // set messages function is to set the messages static property
+  // this is for testing purposes only
+  static setMessages(messages: IterableInAppMessage[]) {
+    MockRNIterableAPI.messages = messages
+  }
 }
 

--- a/ts/__tests__/IterableInApp.spec.ts
+++ b/ts/__tests__/IterableInApp.spec.ts
@@ -80,7 +80,7 @@ test("in-app consume", () => {
   expect(MockRNIterableAPI.inAppConsume).toBeCalledWith(message.messageId, IterableInAppLocation.inApp, IterableInAppDeleteSource.unknown)
 })
 
-test("in-app handler is called", () => {
+test.skip("in-app handler is called", () => {
   MockRNIterableAPI.setInAppShowResponse.mockReset()
 
   const nativeEmitter = new NativeEventEmitter();
@@ -121,9 +121,8 @@ test("get in-app messages", () => {
   }]
 
   const messages = messageDicts.map(message => IterableInAppMessage.fromDict(message))
-  MockRNIterableAPI.getInAppMessages = jest.fn(() => {
-    return new Promise(res => res(messages))
-  })
+
+  MockRNIterableAPI.setMessages(messages)
 
   return Iterable.inAppManager.getMessages().then(messagesObtained => {
     expect(messagesObtained).toEqual(messages)

--- a/ts/__tests__/IterableInApp.spec.ts
+++ b/ts/__tests__/IterableInApp.spec.ts
@@ -109,7 +109,8 @@ test("in-app handler is called", () => {
   })
 })
 
-test("get in-app messages", () => {
+test("getMessages_noParams_returnsMessages", () => {
+  // GIVEN a list of in-app messages representing the local queue
   const messageDicts = [{
     "messageId": "message1",
     "campaignId": 1234,
@@ -122,8 +123,10 @@ test("get in-app messages", () => {
 
   const messages = messageDicts.map(message => IterableInAppMessage.fromDict(message))
 
+  // WHEN the simulated local queue is set to the in-app messages
   MockRNIterableAPI.setMessages(messages)
 
+  // THEN Iterable,inAppManager.getMessages returns the list of in-app messages
   return Iterable.inAppManager.getMessages().then(messagesObtained => {
     expect(messagesObtained).toEqual(messages)
   })

--- a/ts/__tests__/IterableInApp.spec.ts
+++ b/ts/__tests__/IterableInApp.spec.ts
@@ -80,7 +80,7 @@ test("in-app consume", () => {
   expect(MockRNIterableAPI.inAppConsume).toBeCalledWith(message.messageId, IterableInAppLocation.inApp, IterableInAppDeleteSource.unknown)
 })
 
-test.skip("in-app handler is called", () => {
+test("in-app handler is called", () => {
   MockRNIterableAPI.setInAppShowResponse.mockReset()
 
   const nativeEmitter = new NativeEventEmitter();


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-5245](https://iterable.atlassian.net/browse/MOB-5245)

## ✏️ Description

This pull request creates a setMessages function for the MockRNIterableAPI class for testing purposes and refactors the getMessages unit test to remove setting messages from the test body. 
