### PR TITLE
[MOB-5316] adds safeExtGet method to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,15 +3,15 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('compileSdkVersion', 28)
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 def safeExtGet(prop, fallback) {
-    
     return fallback
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,12 +7,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    compileSdkVersion rootProject.ext.get('compileSdkVersion')
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('compileSdkVersion', 28)
-
+        minSdkVersion rootProject.ext.get('minSdkVersion')
+        targetSdkVersion rootProject.ext.get('compileSdkVersion')
+        
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,12 +7,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion rootProject.ext.get('compileSdkVersion')
+    compileSdkVersion rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        minSdkVersion rootProject.ext.get('minSdkVersion')
-        targetSdkVersion rootProject.ext.get('compileSdkVersion')
-        
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.compileSdkVersion
+
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 def safeExtGet(prop, fallback) {
-    return fallback
+    fallback
 }
 
 android {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,16 @@ apply plugin: 'com.android.library'
 
 import groovy.json.JsonSlurper
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 28
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,10 +2,6 @@ apply plugin: 'com.android.library'
 
 import groovy.json.JsonSlurper
 
-def safeExtGet(prop, fallback) {
-    fallback
-}
-
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
@@ -15,6 +11,10 @@ android {
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }
+}
+
+def safeExtGet(prop, fallback) {
+    fallback
 }
 
 def getModuleVersion() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
 }
 
 def safeExtGet(prop, fallback) {
-    fallback
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 def getModuleVersion() {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,11 +7,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 28)
+        minSdkVersion 16
+        targetSdkVersion 28
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,15 +3,16 @@ apply plugin: 'com.android.library'
 import groovy.json.JsonSlurper
 
 def safeExtGet(prop, fallback) {
-    return rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+    
+    return fallback
 }
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.compileSdkVersion
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('compileSdkVersion', 28)
 
         buildConfigField("String", "MODULE_VERSION", "\"${getModuleVersion()}\"")
     }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-5316](https://iterable.atlassian.net/browse/MOB-5316)

## ✏️ Description

This pull request adds the safeExtGet method to inherit the gradle build config values from the parent project rather than hardcoding them.
