### PR TITLE
Pass expiringAuthTokenRefreshPeriod to native sdks

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/Serialization.java
+++ b/android/src/main/java/com/iterable/reactnative/Serialization.java
@@ -167,6 +167,10 @@ class Serialization {
                 configBuilder.setInAppDisplayInterval(iterableContextJSON.optDouble("inAppDisplayInterval"));
             }
 
+            if (iterableContextJSON.has("expiringAuthTokenRefreshPeriod")) {
+                configBuilder.setExpiringAuthTokenRefreshPeriod(iterableContextJSON.optLong("expiringAuthTokenRefreshPeriod"));
+            }
+
             if (iterableContextJSON.has("useInMemoryStorageForInApps") || iterableContextJSON.has("androidSdkUseInMemoryStorageForInApps")) {
                 configBuilder.setUseInMemoryStorageForInApps(iterableContextJSON.optBoolean("useInMemoryStorageForInApps"));
             }

--- a/ios/RNIterableAPI/Serialization.swift
+++ b/ios/RNIterableAPI/Serialization.swift
@@ -59,6 +59,10 @@ extension IterableConfig {
             config.inAppDisplayInterval = inAppDisplayInterval
         }
         
+        if let expiringAuthTokenRefreshPeriod = dict["expiringAuthTokenRefreshPeriod"] as? TimeInterval {
+            config.expiringAuthTokenRefreshPeriod = expiringAuthTokenRefreshPeriod
+        }
+
         if let logLevelNumber = dict["logLevel"] as? NSNumber {
             config.logDelegate = createLogDelegate(logLevelNumber: logLevelNumber)
         }


### PR DESCRIPTION
## ✏️ Description
`expiringAuthTokenRefreshPeriod` was not being passed to the `IterableConfig` in swift or java, leaving it to the default 60s.