### PR TITLE
[MOB-6063] updates parameter types for setEmail and setUserId

### DIFF
--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -210,7 +210,7 @@ class Iterable {
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
    * @param {string | null | undefined} email email address to associate with the current user
-   * @param {string | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
+   * @param {string | null | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
 
   static setEmail(email?: string | null, authToken?: string | null) {
@@ -263,10 +263,10 @@ class Iterable {
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
    * parameters: @param {string | null | undefined} userId user ID to associate with the current user 
-   * optional parameter: @param {string | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
+   * optional parameter: @param {string | null | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
  
-  static setUserId(userId?: string | null, authToken?: string | undefined) {
+  static setUserId(userId?: string | null, authToken?: string | null) {
     Iterable.logger.log("setUserId: " + userId)
 
     RNIterableAPI.setUserId(userId, authToken)

--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -210,7 +210,7 @@ class Iterable {
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
    * @param {string | null | undefined} email email address to associate with the current user
-   * @param {string | null | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
+   * @param {string | null | undefined} authToken valid, pre-fetched JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
 
   static setEmail(email?: string | null, authToken?: string | null) {
@@ -263,7 +263,7 @@ class Iterable {
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
    * parameters: @param {string | null | undefined} userId user ID to associate with the current user 
-   * optional parameter: @param {string | null | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
+   * optional parameter: @param {string | null | undefined} authToken valid, pre-fetched JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
  
   static setUserId(userId?: string | null, authToken?: string | null) {

--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -209,11 +209,11 @@ class Iterable {
    * 
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
-   * @param {string | null} email email address to associate with the current user
+   * @param {string | null | undefined} email email address to associate with the current user
    * @param {string | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
 
-  static setEmail(email: string | null, authToken?: string | null) {
+  static setEmail(email?: string | null, authToken?: string | null) {
     Iterable.logger.log("setEmail: " + email)
 
     RNIterableAPI.setEmail(email, authToken)
@@ -262,11 +262,11 @@ class Iterable {
    * 
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
-   * parameters: @param {string | null} userId user ID to associate with the current user 
+   * parameters: @param {string | null | undefined} userId user ID to associate with the current user 
    * optional parameter: @param {string | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
  
-  static setUserId(userId: string | null, authToken?: string | undefined) {
+  static setUserId(userId?: string | null, authToken?: string | undefined) {
     Iterable.logger.log("setUserId: " + userId)
 
     RNIterableAPI.setUserId(userId, authToken)

--- a/ts/Iterable.ts
+++ b/ts/Iterable.ts
@@ -209,11 +209,11 @@ class Iterable {
    * 
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
-   * @param {string | undefined} email email address to associate with the current user
+   * @param {string | null} email email address to associate with the current user
    * @param {string | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
 
-  static setEmail(email: string | undefined, authToken?: string | undefined) {
+  static setEmail(email: string | null, authToken?: string | null) {
     Iterable.logger.log("setEmail: " + email)
 
     RNIterableAPI.setEmail(email, authToken)
@@ -262,11 +262,11 @@ class Iterable {
    * 
    * Note: specify a user by calling Iterable.setEmail or Iterable.setUserId, but NOT both.
    * 
-   * parameters: @param {string | undefined} userId user ID to associate with the current user 
+   * parameters: @param {string | null} userId user ID to associate with the current user 
    * optional parameter: @param {string | undefined} authToken valid, pre-fecthed JWT the SDK can use to authenticate API requests, optional - if null/undefined, no JWT related action will be taken
    */ 
  
-  static setUserId(userId: string | undefined, authToken?: string | undefined) {
+  static setUserId(userId: string | null, authToken?: string | undefined) {
     Iterable.logger.log("setUserId: " + userId)
 
     RNIterableAPI.setUserId(userId, authToken)


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-6063](https://iterable.atlassian.net/browse/MOB-6063)

## ✏️ Description

This pull request updates the parameter types for setEmail and setUserId. This stems from reported issues with setEmail as discussed [here](https://iterable.atlassian.net/browse/MOB-6063). In our documentation, we ask customers to pass in a value of null to log out.


[MOB-6063]: https://iterable.atlassian.net/browse/MOB-6063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ