### PR TITLE
add support for userId in sample app

### DIFF
--- a/SampleApp/javascript/js/SettingsTab.js
+++ b/SampleApp/javascript/js/SettingsTab.js
@@ -6,14 +6,24 @@ import { Iterable } from '@iterable/react-native-sdk';
 class SettingsTab extends Component {
     constructor(props) {
         super(props);
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
         this.onLoginTapped = () => {
             console.log("onLoginTapped");
-            Iterable.setEmail(this.state.email);
+            if (emailRegex.test(this.state.email)) {
+                Iterable.setEmail(this.state.email);
+                this.updateState();
+            } else {
+                Iterable.setUserId(this.state.email);
+            }
             this.updateState();
         };
         this.onLogoutTapped = () => {
             console.log("onLogoutTapped");
-            Iterable.setEmail(undefined);
+            if (emailRegex.test(this.state.email)) {
+                Iterable.setEmail(undefined);
+            } else{
+                Iterable.setUserId(undefined);
+            }
             this.updateState();
         };
         this.state = { isLoggedIn: false };
@@ -43,7 +53,7 @@ class SettingsTab extends Component {
     renderLoggedOut() {
         console.log("renderLoggedOut");
         return (React.createElement(View, { style: styles.emailContainer },
-            React.createElement(TextInput, { value: this.state.email, style: styles.emailTextInput, autoCapitalize: "none", autoCompleteType: "email", onChangeText: (text) => this.setState({ isLoggedIn: false, email: text }), placeholder: "user@example.com" }),
+            React.createElement(TextInput, { value: this.state.email, style: styles.emailTextInput, autoCapitalize: "none", autoCompleteType: emailRegex.test(this.state.email) ? "email" : "none", onChangeText: (text) => this.setState({ isLoggedIn: false, email: text }), placeholder: "user@example.com/userId" }),
             React.createElement(Button, { title: "Login", onPress: this.onLoginTapped })));
     }
     updateState() {
@@ -53,7 +63,14 @@ class SettingsTab extends Component {
                 this.setState({ isLoggedIn: true, email: email });
             }
             else {
-                this.setState({ isLoggedIn: false, email: undefined });
+                Iterable.getUserId().then(userId => {
+                    console.log("gotUserId: " + userId);
+                    if(userId) {
+                        this.setState({ isLoggedIn: true, email: userId });
+                    } else {
+                        this.setState({ isLoggedIn: false, email: undefined });
+                    }
+                })
             }
         });
     }

--- a/SampleApp/javascript/js/SettingsTab.js
+++ b/SampleApp/javascript/js/SettingsTab.js
@@ -52,6 +52,7 @@ class SettingsTab extends Component {
     }
     renderLoggedOut() {
         console.log("renderLoggedOut");
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
         return (React.createElement(View, { style: styles.emailContainer },
             React.createElement(TextInput, { value: this.state.email, style: styles.emailTextInput, autoCapitalize: "none", autoCompleteType: emailRegex.test(this.state.email) ? "email" : "none", onChangeText: (text) => this.setState({ isLoggedIn: false, email: text }), placeholder: "user@example.com/userId" }),
             React.createElement(Button, { title: "Login", onPress: this.onLoginTapped })));

--- a/SampleApp/typescript/ios/SampleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SampleApp/typescript/ios/SampleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SampleApp/typescript/ios/SampleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SampleApp/typescript/ios/SampleApp.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/SampleApp/typescript/ts/SettingsTab.tsx
+++ b/SampleApp/typescript/ts/SettingsTab.tsx
@@ -56,15 +56,16 @@ class SettingsTab extends Component<Props, State> {
 
   private renderLoggedOut() {
     console.log("renderLoggedOut")
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
     return (
       <View style={styles.emailContainer}>
         <TextInput
           value={this.state.email}
           style={styles.emailTextInput}
           autoCapitalize="none"
-          autoCompleteType="email"
+          autoCompleteType= {emailRegex.test(this.state.email) ? "email" : "none"}
           onChangeText={(text) => this.setState({ isLoggedIn: false, email: text })}
-          placeholder="user@example.com" />
+          placeholder="user@example.com/userId" />
         <Button
           title="Login"
           onPress={this.onLoginTapped}
@@ -75,13 +76,24 @@ class SettingsTab extends Component<Props, State> {
 
   private onLoginTapped = () => {
     console.log("onLoginTapped")
-    Iterable.setEmail(this.state.email)
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (emailRegex.test(this.state.email)) {
+      Iterable.setEmail(this.state.email)
+    } else{
+      Iterable.setUserId(this.state.email)
+    }
     this.updateState()
   }
 
   private onLogoutTapped = () => {
     console.log("onLogoutTapped")
-    Iterable.setEmail(undefined)
+    
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (emailRegex.test(this.state.email)) {
+      Iterable.setEmail(undefined)
+    } else {
+      Iterable.setUserId(undefined)
+    }
     this.updateState()
   }
 
@@ -91,7 +103,14 @@ class SettingsTab extends Component<Props, State> {
       if (email) {
         this.setState({ isLoggedIn: true, email: email })
       } else {
-        this.setState({ isLoggedIn: false, email: undefined })
+        Iterable.getUserId().then(userId => {
+          console.log("gotUserId: " + userId)
+          if (userId) {
+            this.setState({ isLoggedIn: true, email: userId })
+          } else {
+            this.setState({ isLoggedIn: false, email: undefined })
+          }
+        })
       }
     })
   }


### PR DESCRIPTION
## Description

- **Release Notes**
> We have successfully implemented support for the userId in Sample App for both JavaScript and TypeScript Apps.

- **Test Steps**

> 1. Run the Sample App.
> 2. Navigate to the Settings tab.
> 3. Locate the field for entering email/userId.
> 4. Enter the appropriate value and press the login button.
> 5. Verify that the email/userId is displayed as the user.
> 6. Click the Logout button.
> 7. Confirm that the field for entering email/userId is visible again.