### PR TITLE
chore: Upgrade Android Iterableapi to 3.5.3

### DIFF
--- a/SampleApp/typescript/yarn.lock
+++ b/SampleApp/typescript/yarn.lock
@@ -760,10 +760,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@iterable/react-native-sdk@^1.3.11":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@iterable/react-native-sdk/-/react-native-sdk-1.3.12.tgz#e0f3176f45aeacd096a02aeca50f916c39b25ef7"
-  integrity sha512-Cn5xxuQ2+Cretm29hGYrq0zyMhXThaY0yvqRQRvSxDMrOaUGGwHbBnegvuswyDnwVUPHcPh004LuWcgFpZOsRg==
+"@iterable/react-native-sdk@^1.3.20":
+  version "1.3.20"
+  resolved "https://registry.npmjs.org/@iterable/react-native-sdk/-/react-native-sdk-1.3.20.tgz#3233cb4786bf8f7f0d6c926c40ba72d15fc11e4f"
+  integrity sha512-NijwbnTCUWpIIebX11HSBijNESP9GlhRhkoGxFTMeDWd3X1J4I4HVq3g9/QQbX9X3VJQ1AwfbdokETIkRqzIYQ==
   dependencies:
     "@react-native-community/hooks" "^2.6.0"
     "@react-navigation/native" "^6.0.6"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,6 @@ def getModuleVersion() {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    api 'com.iterable:iterableapi:3.5.2'
+    api 'com.iterable:iterableapi:3.5.3'
     // api project(':iterableapi') // links to local android SDK repo rather than by release
 }

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
+import com.iterable.iterableapi.AuthFailure;
 import com.iterable.iterableapi.InboxSessionManager;
 import com.iterable.iterableapi.IterableAction;
 import com.iterable.iterableapi.IterableActionContext;

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -597,7 +597,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     }
 
     @Override
-    public void onTokenRegistrationFailed(Throwable object) {
+    public void onAuthFailure(AuthFailure authFailure) {
         IterableLogger.v(TAG, "Failed to set authToken");
         sendEvent(EventName.handleAuthFailureCalled.name(), null);
     }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

This PR addresses this [issue](https://github.com/Iterable/react-native-sdk/issues/547). The problem has been resolved in the [iterable-android-sdk pull request](https://github.com/Iterable/iterable-android-sdk/pull/738), but the Android package updates have not yet been incorporated into this repository. 
