### PR TITLE
ready: eslint deps are devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.21
+## Fixes
+- Moves lint dependencies into `devDependencies` so that consumers who use `yarn` will not see warnings when installing.
+
 ## 1.3.20
 ## Fixes
 - Fixes an issue where the iOS SDK incorrectly targeted the latest minor version instead of a fixed version, potentially causing breaking changes.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For quick reference, the following table lists the versions of the [Android SDK]
 
 | RN SDK Version                                                              | Android SDK Version                                                          | iOS SDK Version |
 | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------- | --------------- |
+| [1.3.21](https://www.npmjs.com/package/@iterable/react-native-sdk/v/1.3.21) | [3.5.2](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.5.2) | [6.5.4](https://github.com/Iterable/swift-sdk/releases/tag/6.5.4)
 | [1.3.20](https://www.npmjs.com/package/@iterable/react-native-sdk/v/1.3.20) | [3.5.2](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.5.2) | [6.5.4](https://github.com/Iterable/swift-sdk/releases/tag/6.5.4)
 | [1.3.19](https://www.npmjs.com/package/@iterable/react-native-sdk/v/1.3.19) | [3.5.2](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.5.2) | [6.5.3](https://github.com/Iterable/swift-sdk/releases/tag/6.5.3)
 | [1.3.18](https://www.npmjs.com/package/@iterable/react-native-sdk/v/1.3.18) | [3.5.2](https://github.com/Iterable/iterable-android-sdk/releases/tag/3.5.2) | [6.5.3](https://github.com/Iterable/swift-sdk/releases/tag/6.5.3)

--- a/SampleApp/javascript/package.json
+++ b/SampleApp/javascript/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@iterable/react-native-sdk": "^1.3.20",
+    "@iterable/react-native-sdk": "^1.3.21",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/toolbar-android": "^0.1.0-rc.2",
     "@react-navigation/bottom-tabs": "^5.4.5",

--- a/SampleApp/typescript/package.json
+++ b/SampleApp/typescript/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@iterable/react-native-sdk": "^1.3.20",
+    "@iterable/react-native-sdk": "^1.3.21",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-native-community/toolbar-android": "^0.1.0-rc.2",
     "@react-navigation/bottom-tabs": "^5.4.5",

--- a/integration-testing/package.json
+++ b/integration-testing/package.json
@@ -10,7 +10,7 @@
     "e2e:android-release": "npm run build:android-release && npm run test:android-release"
   },
   "dependencies": {
-    "@iterable/react-native-sdk": "^1.3.20",
+    "@iterable/react-native-sdk": "^1.3.21",
     "@react-native-community/masked-view": "^0.1.10",
     "@react-navigation/bottom-tabs": "^5.4.5",
     "@react-navigation/native": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   "dependencies": {
     "@react-native-community/hooks": "^2.6.0",
     "@react-navigation/native": "^6.0.6",
-    "eslint": "^8.0.1",
-    "eslint-config-airbnb": "^19.0.4",
     "react-native-safe-area-context": "^4.1.2",
     "react-native-vector-icons": "^9.0.0",
     "react-native-webview": "^11.0.0"
@@ -38,6 +36,8 @@
     "@types/react-native-vector-icons": "^6.4.10",
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "eslint": "8.57.1",
+    "eslint-config-airbnb": "^19.0.4",
     "eslint-config-standard": "^14.0.0",
     "eslint-config-standard-jsx": "^8.1.0",
     "eslint-config-standard-react": "^9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iterable/react-native-sdk",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "Iterable SDK for React Native.",
   "main": "./js/index.js",
   "types": "./js/index.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,7 +3222,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.0.1:
+eslint@8.57.1:
   version "8.57.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.1.tgz#7df109654aba7e3bbe5c8eae533c5e461d3c6ca9"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==


### PR DESCRIPTION
## Issue

Addresses this issue that I opened earlier today

https://github.com/Iterable/react-native-sdk/issues/595

## ✏️ Description

Move `eslint` and `eslint-config-airbnb` dependencies into the `devDependencies` object in `package.json`.

Thie prevents `yarn` from printing warnings:
```
➤ YN0002: │ @iterable/react-native-sdk@npm:1.3.20 [b01c5] doesn't provide eslint-plugin-import (p67cd9), requested by eslint-config-airbnb
➤ YN0002: │ @iterable/react-native-sdk@npm:1.3.20 [b01c5] doesn't provide eslint-plugin-jsx-a11y (p16ac4), requested by eslint-config-airbnb
➤ YN0002: │ @iterable/react-native-sdk@npm:1.3.20 [b01c5] doesn't provide eslint-plugin-react (pf10d0), requested by eslint-config-airbnb
➤ YN0002: │ @iterable/react-native-sdk@npm:1.3.20 [b01c5] doesn't provide eslint-plugin-react-hooks (p53156), requested by eslint-config-airbnb
```
