### PR TITLE
Upgrade iterable ios sdk from 6.5.4 to 6.5.6

### DIFF
--- a/Iterable-React-Native-SDK.podspec
+++ b/Iterable-React-Native-SDK.podspec
@@ -39,6 +39,6 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.dependency "Iterable-iOS-SDK", "6.5.4"
+  s.dependency "Iterable-iOS-SDK", "6.5.6"
   
 end

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -678,8 +678,13 @@ extension ReactIterableAPI: IterableAuthDelegate {
                                body: nil)
             }
         }
+
+        func onAuthFailure(_ authFailure: IterableSDK.AuthFailure) {
+            
+        }
     }
-    
+
+    // Deprecated in iterable-swift-sdk 6.5.5: https://github.com/Iterable/iterable-swift-sdk/releases/tag/6.5.5
     func onTokenRegistrationFailed(_ reason: String?) {
         
     }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

No Jira ticket, unable to write support tickets myself.  Issue link: https://github.com/Iterable/react-native-sdk/issues/626

## ✏️ Description

Upgrades the Iterable-iOS-SDK from 6.5.4 to 6.5.6 to fix APNS sandbox messaging for iOS 18 that completely broke in iOS 18.3.1.

To handle changes in Iterable-iOS-SDK 6.5.5, adds a new `onAuthFailure` method to the IterableAuthDelegate. It is a no-op method similar to the one it replaced, `onTokenRegistrationFailed`. Was not sure if the replaced method was completely deprecated, so left it in with a note.