### PR TITLE
[MOB-11828] add-backwards-compatibility

### DIFF
--- a/ios/RNIterableAPI/RNIterableAPI.h
+++ b/ios/RNIterableAPI/RNIterableAPI.h
@@ -1,10 +1,18 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTEventEmitter.h>
-#import <React/RCTUtils.h>
-#import <React/RCTConvert.h>
-#import <React/RCTTurboModuleRegistry.h>
-#import <RNIterableAPISpec/RNIterableAPISpec.h>
 
+#if RCT_NEW_ARCH_ENABLED
+
+  #import <React/RCTUtils.h>
+  #import <React/RCTConvert.h>
+  #import <React/RCTTurboModuleRegistry.h>
+  #import <RNIterableAPISpec/RNIterableAPISpec.h>
 @interface RNIterableAPI : RCTEventEmitter <NativeRNIterableAPISpec>
+
+#else
+  #import <React/RCTBridgeModule.h>
+@interface RNIterableAPI : RCTEventEmitter <RCTBridgeModule>
+
+#endif
 
 @end

--- a/ios/RNIterableAPI/RNIterableAPI.mm
+++ b/ios/RNIterableAPI/RNIterableAPI.mm
@@ -1,5 +1,9 @@
 #import "RNIterableAPI.h"
-#import "RNIterableAPISpec.h"
+
+#if RCT_NEW_ARCH_ENABLED
+  #import "RNIterableAPISpec.h"
+#endif
+
 #import <IterableSDK/IterableSDK.h>
 
 // Forward-declare the Swift protocols/enum used in the Swift header
@@ -44,6 +48,10 @@ RCT_EXPORT_MODULE()
   [self sendEventWithName:name body:@(result)];
 }
 
+#if RCT_NEW_ARCH_ENABLED
+
+// MARK: - New Architecture functions exposed to JS
+
 - (void)startObserving {
   [(ReactIterableAPI *)_swiftAPI startObserving];
 }
@@ -52,7 +60,6 @@ RCT_EXPORT_MODULE()
   [(ReactIterableAPI *)_swiftAPI stopObserving];
 }
 
-// MARK: - RNIterableAPI functions exposed to JS
 - (void)initializeWithApiKey:(NSString *)apiKey
                       config:(NSDictionary *)config
                      version:(NSString *)version
@@ -271,5 +278,223 @@ RCT_EXPORT_MODULE()
     (const facebook::react::ObjCTurboModule::InitParams &)params {
   return std::make_shared<facebook::react::NativeRNIterableAPISpecJSI>(params);
 }
+
+#else
+
+// MARK: - RCTBridgeModule integration for Legacy Architecture
+
+RCT_EXPORT_METHOD(startObserving) {
+  [(ReactIterableAPI *)_swiftAPI startObserving];
+}
+
+RCT_EXPORT_METHOD(stopObserving) {
+  [(ReactIterableAPI *)_swiftAPI stopObserving];
+}
+
+RCT_EXPORT_METHOD(
+    initializeWithApiKey : (NSString *)apiKey config : (NSDictionary *)
+        config version : (NSString *)version resolve : (RCTPromiseResolveBlock)
+            resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI initializeWithApiKey:apiKey
+                           config:config
+                          version:version
+                         resolver:resolve
+                         rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(
+    initialize2WithApiKey : (NSString *)apiKey config : (NSDictionary *)
+        config version : (NSString *)version apiEndPointOverride : (NSString *)
+            apiEndPointOverride resolve : (RCTPromiseResolveBlock)
+                resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI initialize2WithApiKey:apiKey
+                            config:config
+               apiEndPointOverride:apiEndPointOverride
+                           version:version
+                          resolver:resolve
+                          rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(setEmail : (NSString *_Nullable)
+                      email authToken : (NSString *_Nullable)authToken) {
+  [_swiftAPI setEmail:email authToken:authToken];
+}
+
+RCT_EXPORT_METHOD(getEmail : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getEmail:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(setUserId : (NSString *_Nullable)
+                      userId authToken : (NSString *_Nullable)authToken) {
+  [_swiftAPI setUserId:userId authToken:authToken];
+}
+
+RCT_EXPORT_METHOD(getUserId : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getUserId:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(setInAppShowResponse : (NSNumber *)inAppShowResponse) {
+  [_swiftAPI setInAppShowResponse:inAppShowResponse];
+}
+
+RCT_EXPORT_METHOD(getInAppMessages : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getInAppMessages:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(getInboxMessages : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getInboxMessages:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(getUnreadInboxMessagesCount : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getUnreadInboxMessagesCount:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(showMessage : (NSString *)messageId consume : (BOOL)
+                      consume resolve : (RCTPromiseResolveBlock)
+                          resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI showMessage:messageId
+                 consume:consume
+                resolver:resolve
+                rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(removeMessage : (NSString *)messageId location : (NSNumber *)
+                      location source : (NSNumber *)source) {
+  [_swiftAPI removeMessage:messageId location:location source:source];
+}
+
+RCT_EXPORT_METHOD(setReadForMessage : (NSString *)messageId read : (BOOL)read) {
+  [_swiftAPI setReadForMessage:messageId read:read];
+}
+
+RCT_EXPORT_METHOD(setAutoDisplayPaused : (BOOL)autoDisplayPaused) {
+  [_swiftAPI setAutoDisplayPaused:autoDisplayPaused];
+}
+
+RCT_EXPORT_METHOD(trackEvent : (NSString *)name dataFields : (NSDictionary *)
+                      dataFields) {
+  [_swiftAPI trackEvent:name dataFields:dataFields];
+}
+
+RCT_EXPORT_METHOD(
+    trackPushOpenWithCampaignId : (NSNumber *)
+        campaignId templateId : (NSNumber *)templateId messageId : (NSString *)
+            messageId appAlreadyRunning : (BOOL)
+                appAlreadyRunning dataFields : (NSDictionary *)dataFields) {
+  [_swiftAPI trackPushOpenWithCampaignId:campaignId
+                              templateId:templateId
+                               messageId:messageId
+                       appAlreadyRunning:appAlreadyRunning
+                              dataFields:dataFields];
+}
+
+RCT_EXPORT_METHOD(trackInAppOpen : (NSString *)messageId location : (NSNumber *)
+                      location) {
+  [_swiftAPI trackInAppOpen:messageId location:location];
+}
+
+RCT_EXPORT_METHOD(trackInAppClick : (NSString *)messageId location : (
+    NSNumber *)location clickedUrl : (NSString *)clickedUrl) {
+  [_swiftAPI trackInAppClick:messageId location:location clickedUrl:clickedUrl];
+}
+
+RCT_EXPORT_METHOD(trackInAppClose : (NSString *)messageId location : (
+    NSNumber *)location source : (NSNumber *)source clickedUrl : (NSString *)
+                      clickedUrl) {
+  [_swiftAPI trackInAppClose:messageId
+                    location:location
+                      source:source
+                  clickedUrl:clickedUrl];
+}
+
+RCT_EXPORT_METHOD(inAppConsume : (NSString *)messageId location : (NSNumber *)
+                      location source : (NSNumber *)source) {
+  [_swiftAPI inAppConsume:messageId location:location source:source];
+}
+
+RCT_EXPORT_METHOD(updateCart : (NSArray *)items) {
+  [_swiftAPI updateCart:items];
+}
+
+RCT_EXPORT_METHOD(trackPurchase : (NSNumber *)total items : (NSArray *)
+                      items dataFields : (NSDictionary *)dataFields) {
+  [_swiftAPI trackPurchase:total items:items dataFields:dataFields];
+}
+
+RCT_EXPORT_METHOD(updateUser : (NSDictionary *)dataFields mergeNestedObjects : (
+    BOOL)mergeNestedObjects) {
+  [_swiftAPI updateUser:dataFields mergeNestedObjects:mergeNestedObjects];
+}
+RCT_EXPORT_METHOD(updateEmail : (NSString *)email authToken : (NSString *)
+                      authToken) {
+  [_swiftAPI updateEmail:email authToken:authToken];
+}
+
+RCT_EXPORT_METHOD(getAttributionInfo : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getAttributionInfo:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(setAttributionInfo : (NSDictionary *)attributionInfo) {
+  [_swiftAPI setAttributionInfo:attributionInfo];
+}
+
+RCT_EXPORT_METHOD(disableDeviceForCurrentUser) {
+  [_swiftAPI disableDeviceForCurrentUser];
+}
+
+RCT_EXPORT_METHOD(getLastPushPayload : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getLastPushPayload:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(getHtmlInAppContentForMessage : (NSString *)
+                      messageId resolve : (RCTPromiseResolveBlock)
+                          resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI getHtmlInAppContentForMessage:messageId
+                                  resolver:resolve
+                                  rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(handleAppLink : (NSString *)appLink resolve : (
+    RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject) {
+  [_swiftAPI handleAppLink:appLink resolver:resolve rejecter:reject];
+}
+
+RCT_EXPORT_METHOD(
+    updateSubscriptions : (NSArray *)emailListIds unsubscribedChannelIds : (
+        NSArray *)
+        unsubscribedChannelIds unsubscribedMessageTypeIds : (NSArray *)
+            unsubscribedMessageTypeIds subscribedMessageTypeIds : (NSArray *)
+                subscribedMessageTypeIds campaignId : (NSNumber *)
+                    campaignId templateId : (NSNumber *)templateId) {
+  [_swiftAPI updateSubscriptions:emailListIds
+          unsubscribedChannelIds:unsubscribedChannelIds
+      unsubscribedMessageTypeIds:unsubscribedMessageTypeIds
+        subscribedMessageTypeIds:subscribedMessageTypeIds
+                      campaignId:campaignId
+                      templateId:templateId];
+}
+
+RCT_EXPORT_METHOD(startSession : (NSArray *)visibleRows) {
+  [_swiftAPI startSession:visibleRows];
+}
+
+RCT_EXPORT_METHOD(endSession) { [_swiftAPI endSession]; }
+
+RCT_EXPORT_METHOD(updateVisibleRows : (NSArray *)visibleRows) {
+  [_swiftAPI updateVisibleRows:visibleRows];
+}
+
+RCT_EXPORT_METHOD(passAlongAuthToken : (NSString *)authToken) {
+  [_swiftAPI passAlongAuthToken:authToken];
+}
+
+#endif
 
 @end


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-11828](https://iterable.atlassian.net/browse/MOB-11828)

## ✏️ Description

Update our codebase to support legacy ios architecture in iOS.

## Testing
Building the iOS version of this app in *legacy arch* should work
- open *example>ios>podfile*
	- change `ENV['RCT_NEW_ARCH_ENABLED'] = '1'` to `ENV['RCT_NEW_ARCH_ENABLED'] = '0'`
- in *example>ios*, run the following:
	- `bundle exec pod deintegrate`
	- `rm -rf ~/Library/Developer/Xcode/DerivedData Pods Podfile.lock build ../Gemfile.lock`
	- `bundle install`
	- `bundle exec pod install`
- in *example* run:
	-  `watchman watch-del-all`
	- `yarn start --reset-cache`
- build the ios app

The app should build and load correctly


[MOB-11828]: https://iterable.atlassian.net/browse/MOB-11828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ