### PR TITLE
update coverage reporting for Qlty Cloud

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,25 +29,23 @@ jobs:
         with:
           hide-comment: false
           coverage-summary-path: ./coverage/coverage-summary.json
-  test-code-climate:
-    name: Upload unit test results to Code Climate
+          
+  run-tests-and-publish-coverage:
+    name: Upload unit test results to qlty
     runs-on: ubuntu-latest
-
+  
     steps:
       - uses: actions/checkout@v3
-
+  
       - name: Setup
         uses: ./.github/actions/setup
-
+  
       - name: Run tests
         run: |
           yarn test --coverage --coverageReporters lcov
-
-      - name: Upload coverage to Code Climate
-        uses: paambaati/codeclimate-action@v9.0.0
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+  
+      - name: Upload coverage to qlty
+        uses: qltysh/qlty-action/coverage@v1
         with:
-          coverageCommand: yarn test --coverage --coverageReporters lcov
-          coverageLocations: |
-            ${{github.workspace}}/coverage/lcov.info:lcov
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/lcov.info


### PR DESCRIPTION
## ✏️ Description

This PR:
1.  Updates the CI workflow to publish coverage reports to Qlty Cloud (the new version of Code Climate Quality). 
2. Removes references to the (deprecated) `codeclimate-action`
3. @lposen you'll need to store this repo's new [coverage token](https://docs.qlty.sh/migration/coverage#step-2-store-the-coverage-token-as-a-ci-secret-if-not-using-oidc) as a secret (`QLTY_COVERAGE_TOKEN`). You can grab the token from the Project Settings [here](https://qlty.sh/gh/Iterable/projects/react-native-sdk/settings/coverage).

