### PR TITLE
feat: authfailure handled on native android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -95,7 +95,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  api "com.iterable:iterableapi:3.5.2"
-    // api project(":iterableapi") // links to local android SDK repo rather than by release
+  api "com.iterable:iterableapi:3.5.10"
+//  api project(":iterableapi") // links to local android SDK repo rather than by release
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModule.java
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;
+import com.iterable.iterableapi.AuthFailure;
 import com.iterable.iterableapi.InboxSessionManager;
 import com.iterable.iterableapi.IterableAction;
 import com.iterable.iterableapi.IterableActionContext;
@@ -109,7 +110,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     @ReactMethod
     public void setEmail(@Nullable String email) {
         IterableLogger.d(TAG, "setEmail: " + email);
-        
+
         IterableApi.getInstance().setEmail(email);
     }
 
@@ -154,7 +155,7 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
     @ReactMethod
     public void setUserId(@Nullable String userId, @Nullable String authToken) {
         IterableLogger.d(TAG, "setUserId: " + userId + " authToken: " + authToken);
-        
+
         IterableApi.getInstance().setUserId(userId, authToken);
     }
 
@@ -595,12 +596,26 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule implements I
         // MOB-10422: Pass successhandler to event listener
         sendEvent(EventName.handleAuthSuccessCalled.name(), null);
     }
+    
+  @Override
+  public void onAuthFailure(AuthFailure authFailure) {
 
-    @Override
-    public void onTokenRegistrationFailed(Throwable object) {
-        IterableLogger.v(TAG, "Failed to set authToken");
-        sendEvent(EventName.handleAuthFailureCalled.name(), null);
+      //Create a JSON object for the authFailure object
+    JSONObject messageJson = new JSONObject();
+    try {
+      messageJson.put("userKey", authFailure.userKey);
+      messageJson.put("failedAuthToken", authFailure.failedAuthToken);
+      messageJson.put("failedRequestTime", authFailure.failedRequestTime);
+      messageJson.put("failureReason", authFailure.failureReason.name());
+      WritableMap eventData = Serialization.convertJsonToMap(messageJson);
+      sendEvent(EventName.handleUrlCalled.name(), eventData);
+    } catch (JSONException e) {
+      IterableLogger.v(TAG, "Failed to set authToken");
     }
+
+
+
+  }
 
     @ReactMethod
     public void addListener(String eventName) {


### PR DESCRIPTION
- SDK now implemented onAuthFailure on native bridge. It converts the Authfailure object to WriteableMap
- TS layer AuthLayer is pending

## 🔹 JIRA Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

> Please provide a brief description of what this pull request does.
