### PR TITLE
[MOB-12251] temporary fix for circular paths, which break expo

### DIFF
--- a/src/inApp/classes/IterableHtmlInAppContent.ts
+++ b/src/inApp/classes/IterableHtmlInAppContent.ts
@@ -1,4 +1,4 @@
-import { IterableEdgeInsets } from '../../core';
+import { IterableEdgeInsets } from '../../core/classes/IterableEdgeInsets';
 
 import { IterableInAppContentType } from '../enums';
 import type {

--- a/src/inApp/classes/IterableInAppManager.ts
+++ b/src/inApp/classes/IterableInAppManager.ts
@@ -1,5 +1,4 @@
 import { RNIterableAPI } from '../../api';
-import { Iterable } from '../../core/classes/Iterable';
 import type {
   IterableInAppDeleteSource,
   IterableInAppLocation,
@@ -33,9 +32,11 @@ export class IterableInAppManager {
    * @returns A Promise that resolves to an array of in-app messages.
    */
   getMessages(): Promise<IterableInAppMessage[]> {
-    Iterable?.logger?.log('InAppManager.getMessages');
+    // Iterable?.logger?.log('InAppManager.getMessages');
 
-    return RNIterableAPI.getInAppMessages() as unknown as Promise<IterableInAppMessage[]>;
+    return RNIterableAPI.getInAppMessages() as unknown as Promise<
+      IterableInAppMessage[]
+    >;
   }
 
   /**
@@ -56,9 +57,11 @@ export class IterableInAppManager {
    * @returns A Promise that resolves to an array of messages marked as `saveToInbox`.
    */
   getInboxMessages(): Promise<IterableInAppMessage[]> {
-    Iterable?.logger?.log('InAppManager.getInboxMessages');
+    // Iterable?.logger?.log('InAppManager.getInboxMessages');
 
-    return RNIterableAPI.getInboxMessages() as unknown as Promise<IterableInAppMessage[]>;
+    return RNIterableAPI.getInboxMessages() as unknown as Promise<
+      IterableInAppMessage[]
+    >;
   }
 
   /**
@@ -83,7 +86,7 @@ export class IterableInAppManager {
     message: IterableInAppMessage,
     consume: boolean
   ): Promise<string | null> {
-    Iterable?.logger?.log('InAppManager.show');
+    // Iterable?.logger?.log('InAppManager.show');
 
     return RNIterableAPI.showMessage(message.messageId, consume);
   }
@@ -111,7 +114,7 @@ export class IterableInAppManager {
     location: IterableInAppLocation,
     source: IterableInAppDeleteSource
   ): void {
-    Iterable?.logger?.log('InAppManager.remove');
+    // Iterable?.logger?.log('InAppManager.remove');
 
     return RNIterableAPI.removeMessage(message.messageId, location, source);
   }
@@ -128,7 +131,7 @@ export class IterableInAppManager {
    * ```
    */
   setReadForMessage(message: IterableInAppMessage, read: boolean) {
-    Iterable?.logger?.log('InAppManager.setRead');
+    // Iterable?.logger?.log('InAppManager.setRead');
 
     RNIterableAPI.setReadForMessage(message.messageId, read);
   }
@@ -148,9 +151,11 @@ export class IterableInAppManager {
   getHtmlContentForMessage(
     message: IterableInAppMessage
   ): Promise<IterableHtmlInAppContent> {
-    Iterable?.logger?.log('InAppManager.getHtmlContentForMessage');
+    // Iterable?.logger?.log('InAppManager.getHtmlContentForMessage');
 
-    return RNIterableAPI.getHtmlInAppContentForMessage(message.messageId) as unknown as Promise<IterableHtmlInAppContent>;
+    return RNIterableAPI.getHtmlInAppContentForMessage(
+      message.messageId
+    ) as unknown as Promise<IterableHtmlInAppContent>;
   }
 
   /**
@@ -168,7 +173,7 @@ export class IterableInAppManager {
    * ```
    */
   setAutoDisplayPaused(paused: boolean) {
-    Iterable?.logger?.log('InAppManager.setAutoDisplayPaused');
+    // Iterable?.logger?.log('InAppManager.setAutoDisplayPaused');
 
     RNIterableAPI.setAutoDisplayPaused(paused);
   }


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [MOB-12251](https://iterable.atlassian.net/browse/MOB-12251)

## ✏️ Description

Fix circular paths

## Test

- pull branch
- from the command line, run the following (you may be prompted to install things):
	```bash
	npx madge --circular --extensions ts ./
	```
- the result should be that there are no circular dependencies
<img width="620" height="95" alt="Screenshot 2025-10-09 at 5 16 17 AM" src="https://github.com/user-attachments/assets/f70b374d-488d-440f-b4c2-50431999e41f" />


[MOB-12251]: https://iterable.atlassian.net/browse/MOB-12251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ