### PR TITLE
SDK-392 Add defensive timeout to iOS initialize to prevent promise hang

### DIFF
--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -645,21 +645,38 @@ import React
       name: Notification.Name.iterableInboxChanged, object: nil)
 
     DispatchQueue.main.async {
+      var hasResolved = false
+      let resolveOnce: (Bool) -> Void = { result in
+        guard !hasResolved else { return }
+        hasResolved = true
+        resolver(result)
+      }
+
+      // Defensive timeout: resolve the JS promise if the native SDK callback
+      // is never invoked (e.g. auth handler event cannot reach JS in New
+      // Architecture bridgeless mode, or network fetch hangs).
+      let timeoutWorkItem = DispatchWorkItem {
+        ITBInfo("initialize timeout reached – resolving promise to unblock JS")
+        resolveOnce(true)
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: timeoutWorkItem)
+
       IterableAPI.initialize2(
         apiKey: apiKey,
         launchOptions: launchOptions,
         config: iterableConfig,
         apiEndPointOverride: apiEndPointOverride
       ) { result in
-        resolver(result)
+        timeoutWorkItem.cancel()
+        resolveOnce(result)
       }
 
       IterableAPI.setDeviceAttribute(name: "reactNativeSDKVersion", value: version)
-      
+
       // Add embedded update listener if any callback is present
       let onEmbeddedMessageUpdatePresent = configDict["onEmbeddedMessageUpdatePresent"] as? Bool ?? false
       let onEmbeddedMessagingDisabledPresent = configDict["onEmbeddedMessagingDisabledPresent"] as? Bool ?? false
-      
+
       if onEmbeddedMessageUpdatePresent || onEmbeddedMessagingDisabledPresent {
         IterableAPI.embeddedManager.addUpdateListener(self)
       }


### PR DESCRIPTION
## What

Adds a 10-second defensive timeout to `ReactIterableAPI.initialize()` on iOS so the JS promise resolves even if the native `IterableAPI.initialize2` callback is never invoked.

**Reported by**: CarGurus (SDK-392) — `Iterable.initialize()` promise hangs indefinitely on React Native New Architecture.

## Root Cause

In New Architecture bridgeless mode, `RCTEventEmitter` events may not reach JS (bridge is nil). When `authHandler` is configured with a saved user, the native SDK's `onAuthTokenRequested` sends an event to JS and blocks for 30s — but JS never receives it. The nil auth token causes a 401 JWT error on the in-app fetch, which enters a retry loop in the Swift SDK's `RequestProcessorUtil`. When retries are exhausted, a bug in `AuthManager.requestNewAuthToken()` causes the `Pending`/`Fulfill` to never resolve — so the `initialize2` callback never fires, and the JS promise hangs forever.

**Companion fix**: The underlying Swift SDK bug is addressed in https://github.com/Iterable/iterable-swift-sdk/pull/1023. This timeout is a defensive workaround that:
- Unblocks customers on older Swift SDK versions
- Covers other edge cases where the callback never fires (network hangs, etc.)
- Resolves the promise faster than waiting for `maxRetry × retryInterval` + 30s auth timeout

## Changes

- `ios/RNIterableAPI/ReactIterableAPI.swift`: Wrap the `resolver` in a `resolveOnce` guard and schedule a 10-second timeout via `DispatchWorkItem`. If the native callback fires normally, the timeout is cancelled. If not, the promise resolves with `true` after 10s. The SDK still initializes and functions normally regardless — only the JS promise is unblocked.

## Regression Risk Analysis

### Low risk
- **Normal init (callback fires within 10s)**: Timeout is cancelled, `resolveOnce` ensures resolver is called exactly once with the real result. No behavior change.
- **Android**: Unaffected — Android `initialize` resolves synchronously.

### Medium risk — review carefully
- **Init takes >10s legitimately**: If the native SDK callback genuinely takes >10s (e.g. very slow network for in-app fetch), the promise resolves with `true` before the actual result is known. The SDK is still initializing in the background. Callers that depend on the promise result to know if init truly succeeded would get a false positive. In practice, CarGurus confirmed the SDK does initialize and respond to lifecycle events even when the promise hangs — so resolving with `true` matches actual behavior.

### Not affected
- All other native module methods (they don't go through this init path)
- Old Architecture (bridge exists, events reach JS, callback fires normally)

## Testing

**How to test:**
1. Enable New Architecture in the example app
2. Configure `IterableConfig` with `authHandler` set
3. Have a saved user (email or userId) in UserDefaults
4. Call `Iterable.initialize()` and verify the promise resolves within ~10s
5. Verify the SDK still functions (can track events, receive in-apps, etc.) after timeout resolution
6. On Old Architecture, verify normal init behavior is unchanged (callback fires, timeout is cancelled)