### PR TITLE
Sumeru / #778 - Fix build failures with Xcode 26 on ARM64

### DIFF
--- a/Iterable-React-Native-SDK.podspec
+++ b/Iterable-React-Native-SDK.podspec
@@ -23,9 +23,11 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE'      => 'YES',
     'CLANG_ENABLE_MODULES' => 'YES',
-    'SWIFT_VERSION'       => '5.3',
+    'SWIFT_VERSION'       => '5.0',
     'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'Iterable_React_Native_SDK-Swift.h',
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    'LIBRARY_SEARCH_PATHS' => '$(inherited) "$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)" "$(SDKROOT)/usr/lib/swift"',
+    'OTHER_LDFLAGS' => '$(inherited) -L"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)" -L"$(SDKROOT)/usr/lib/swift"',
   }
 
   install_modules_dependencies(s)

--- a/ios/RNIterableAPI.xcodeproj/project.pbxproj
+++ b/ios/RNIterableAPI.xcodeproj/project.pbxproj
@@ -260,6 +260,11 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(SDKROOT)/usr/lib/swift\"",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -279,6 +284,11 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
+					"\"$(SDKROOT)/usr/lib/swift\"",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Summary
- Add explicit Swift library search paths to podspec and Xcode project to resolve linker errors for `swiftCompatibility56` and `swiftCompatibilityPacks`
- Update `SWIFT_VERSION` to `5.0` for broader Xcode 26 compatibility
- Adds `LIBRARY_SEARCH_PATHS` and `OTHER_LDFLAGS` pointing to the Swift toolchain and SDK lib directories

## Test plan
- [ ] Build on Xcode 26 with ARM64 architecture
- [ ] Verify CI builds pass
- [ ] Verify backward compatibility with older Xcode versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)