### PR TITLE
Sumeru / #774 - Fix Iterable_React_Native_SDK-Swift.h file not found

### DIFF
--- a/Iterable-React-Native-SDK.podspec
+++ b/Iterable-React-Native-SDK.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
     'CLANG_ENABLE_MODULES' => 'YES',
     'SWIFT_VERSION'       => '5.3',
     'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'Iterable_React_Native_SDK-Swift.h',
+    'HEADER_SEARCH_PATHS' => '$(DERIVED_SOURCES_DIR)',
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
   }
 


### PR DESCRIPTION
## Summary
- Add `HEADER_SEARCH_PATHS` => `$(DERIVED_SOURCES_DIR)` to podspec so the compiler can locate the auto-generated Swift bridging header

## Test plan
- [ ] Build iOS project from clean state (`pod install` + build)
- [ ] Verify Swift interop works correctly
- [ ] Test with both old and new architecture

🤖 Generated with [Claude Code](https://claude.com/claude-code)