### PR TITLE
Fix build compatibility with Xcode 26

### DIFF
--- a/Iterable-React-Native-SDK.podspec
+++ b/Iterable-React-Native-SDK.podspec
@@ -16,6 +16,8 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.private_header_files = "ios/**/*.h"
 
+  s.swift_version = '5.9'
+
   # Load Iterables iOS SDK as a dependency
   s.dependency "Iterable-iOS-SDK", "6.6.7"
 
@@ -23,9 +25,10 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE'      => 'YES',
     'CLANG_ENABLE_MODULES' => 'YES',
-    'SWIFT_VERSION'       => '5.3',
+    'SWIFT_VERSION'       => '5.9',
     'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'Iterable_React_Native_SDK-Swift.h',
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    'ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES' => '$(inherited)',
   }
 
   install_modules_dependencies(s)

--- a/ios/RNIterableAPI.xcodeproj/project.pbxproj
+++ b/ios/RNIterableAPI.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -283,7 +283,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;


### PR DESCRIPTION
## Summary
- Update Swift version from 5.0/5.3 to 5.9 in podspec and Xcode project settings to eliminate dependency on removed `swiftCompatibility56` and `swiftCompatibilityPacks` libraries
- Add `s.swift_version = '5.9'` for proper CocoaPods Swift version resolution
- Add `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = $(inherited)` to pod target xcconfig to fix linking issues


## Test plan
- [ ] Build with Xcode 26 on ARM64
- [ ] Build with Xcode 16.4 still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)