### PR TITLE
Fix Swift bridging header import in RNIterableAPI.mm

### DIFF
--- a/Iterable-React-Native-SDK.podspec
+++ b/Iterable-React-Native-SDK.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
     'CLANG_ENABLE_MODULES' => 'YES',
     'SWIFT_VERSION'       => '5.3',
     'SWIFT_OBJC_INTERFACE_HEADER_NAME' => 'Iterable_React_Native_SDK-Swift.h',
+    'HEADER_SEARCH_PATHS' => '$(DERIVED_SOURCES_DIR)',
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
   }
 


### PR DESCRIPTION
## Summary
- Add `HEADER_SEARCH_PATHS` (`$(DERIVED_SOURCES_DIR)`) to the podspec's `pod_target_xcconfig` so the compiler can locate the auto-generated `Iterable_React_Native_SDK-Swift.h` bridging header
- The Swift compiler places the generated ObjC interface header in `DERIVED_SOURCES_DIR`, but without an explicit search path the Clang compiler cannot find it during the ObjC compilation of `RNIterableAPI.mm`


## Test plan
- [ ] iOS build succeeds with version 2.1.0
- [ ] Swift/ObjC interop works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)