### PR TITLE
Update peer dependencies for React Native 0.84 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,13 +72,13 @@ android {
     }
   }
 
-  lintOptions {
+  lint {
     disable "GradleCompatible"
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   sourceSets {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -4,4 +4,3 @@ RNIterable_targetSdkVersion=35
 RNIterable_compileSdkVersion=35
 RNIterable_ndkversion=27.1.12297006
 android.useAndroidX=true
-android.enableJetifier=true

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "peerDependencies": {
     "@react-navigation/native": "*",
     "react": "*",
-    "react-native": "*",
+    "react-native": ">=0.70.0",
     "react-native-safe-area-context": "*",
     "react-native-webview": "*"
   },


### PR DESCRIPTION
## Summary
- Update react-native peer dependency range to support 0.84.x
- Replace deprecated `lintOptions` with `lint` block in Android build.gradle
- Update Java source/target compatibility from 1.8 to 17 (required by RN 0.84)
- Remove deprecated `android.enableJetifier` property


## Test plan
- [ ] Build with RN 0.84.1
- [ ] Build with older RN versions still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)