### PR TITLE
Surface push registration errors instead of failing silently

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModuleImpl.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModuleImpl.java
@@ -681,6 +681,20 @@ public class RNIterableAPIModuleImpl implements IterableUrlHandler, IterableCust
         sendEvent(EventName.handleAuthSuccessCalled.name(), null);
     }
 
+    @Override
+    public void onTokenRegistrationFailed(String reason) {
+        String failureReason = reason != null ? reason : "unknown reason";
+        IterableLogger.e(TAG, "Push token registration failed: " + failureReason);
+        JSONObject eventDataJson = new JSONObject();
+        try {
+            eventDataJson.put("reason", failureReason);
+            WritableMap eventData = Serialization.convertJsonToMap(eventDataJson);
+            sendEvent(EventName.handleTokenRegistrationFailedCalled.name(), eventData);
+        } catch (JSONException e) {
+            IterableLogger.e(TAG, "Failed to send token registration failure event");
+        }
+    }
+
     public void addListener(String eventName) {
         // Keep: Required for RN built in Event Emitter Calls.
     }
@@ -811,5 +825,6 @@ enum EventName {
   handleInAppCalled,
   handleUrlCalled,
   receivedIterableEmbeddedMessagesChanged,
-  receivedIterableInboxChanged
+  receivedIterableInboxChanged,
+  handleTokenRegistrationFailedCalled
 }

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -35,6 +35,7 @@ import React
     case handleAuthFailureCalled
     case handleEmbeddedMessageUpdateCalled
     case handleEmbeddedMessagingDisabledCalled
+    case handleTokenRegistrationFailedCalled
   }
 
   @objc public static var supportedEvents: [String] {
@@ -818,6 +819,14 @@ extension ReactIterableAPI: IterableAuthDelegate {
   }
 
   public func onTokenRegistrationFailed(_ reason: String?) {
+    let failureReason = reason ?? "unknown reason"
+    ITBError("Push token registration failed: \(failureReason)")
+    guard shouldEmit else {
+      return
+    }
+    delegate?.sendEvent(
+      withName: EventName.handleTokenRegistrationFailedCalled.rawValue,
+      body: ["reason": failureReason] as [String: Any])
   }
 }
 

--- a/src/core/classes/Iterable.ts
+++ b/src/core/classes/Iterable.ts
@@ -956,6 +956,9 @@ export class Iterable {
     RNEventEmitter.removeAllListeners(
       IterableEventName.handleEmbeddedMessagingDisabledCalled
     );
+    RNEventEmitter.removeAllListeners(
+      IterableEventName.handleTokenRegistrationFailedCalled
+    );
   }
 
   /**
@@ -1109,6 +1112,19 @@ export class Iterable {
         );
       }
     }
+
+    // Always listen for token registration failures so they are surfaced
+    RNEventEmitter.addListener(
+      IterableEventName.handleTokenRegistrationFailedCalled,
+      (dict: { reason: string }) => {
+        IterableLogger?.log(
+          'Push token registration failed: ' + (dict?.reason ?? 'unknown reason')
+        );
+        Iterable.savedConfig.onTokenRegistrationFailed?.(
+          dict?.reason ?? 'unknown reason'
+        );
+      }
+    );
   }
 
   /**

--- a/src/core/classes/IterableConfig.ts
+++ b/src/core/classes/IterableConfig.ts
@@ -376,6 +376,25 @@ export class IterableConfig {
   onEmbeddedMessagingDisabled?: () => void;
 
   /**
+   * A callback function that is called when device token registration fails.
+   *
+   * This can happen when the pushIntegrationName is invalid or when the
+   * registerDeviceToken API call fails for any reason.
+   *
+   * @param reason - A string describing why the registration failed.
+   *
+   * @example
+   * ```typescript
+   * const config = new IterableConfig();
+   * config.onTokenRegistrationFailed = (reason) => {
+   *   console.error('Push registration failed:', reason);
+   * };
+   * Iterable.initialize('<YOUR_API_KEY>', config);
+   * ```
+   */
+  onTokenRegistrationFailed?: (reason: string) => void;
+
+  /**
    * Converts the IterableConfig instance to a dictionary object.
    *
    * @returns An object representing the configuration.

--- a/src/core/enums/IterableEventName.ts
+++ b/src/core/enums/IterableEventName.ts
@@ -23,4 +23,6 @@ export enum IterableEventName {
   handleEmbeddedMessageUpdateCalled = 'handleEmbeddedMessageUpdateCalled',
   /** Event that fires when embedded messaging is disabled */
   handleEmbeddedMessagingDisabledCalled = 'handleEmbeddedMessagingDisabledCalled',
+  /** Event that fires when push token registration fails */
+  handleTokenRegistrationFailedCalled = 'handleTokenRegistrationFailedCalled',
 }


### PR DESCRIPTION
## Summary
- Add error logging when device token registration fails on both iOS and Android native modules
- Emit a `handleTokenRegistrationFailedCalled` event from native to JS when registration fails
- Add `onTokenRegistrationFailed` callback to `IterableConfig` so JS code can listen for registration failures


## Test plan
- [ ] Set invalid pushIntegrationName, verify error is logged in native console
- [ ] Set invalid pushIntegrationName, verify `onTokenRegistrationFailed` callback fires with reason
- [ ] Set valid pushIntegrationName, verify registration succeeds silently (no error event)

🤖 Generated with [Claude Code](https://claude.com/claude-code)