### PR TITLE
Add method to re-enable push notifications after disabling

### DIFF
--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModuleImpl.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModuleImpl.java
@@ -373,6 +373,11 @@ public class RNIterableAPIModuleImpl implements IterableUrlHandler, IterableCust
         IterableApi.getInstance().disablePush();
     }
 
+    public void registerForPush() {
+        IterableLogger.v(TAG, "registerForPush");
+        IterableApi.getInstance().registerForPush();
+    }
+
     public void handleAppLink(String uri, Promise promise) {
         IterableLogger.printInfo();
         promise.resolve(IterableApi.getInstance().handleAppLink(uri));

--- a/android/src/newarch/java/com/RNIterableAPIModule.java
+++ b/android/src/newarch/java/com/RNIterableAPIModule.java
@@ -138,6 +138,11 @@ public class RNIterableAPIModule extends NativeRNIterableAPISpec {
   }
 
   @Override
+  public void registerForPush() {
+    moduleImpl.registerForPush();
+  }
+
+  @Override
   public void handleAppLink(String uri, Promise promise) {
     moduleImpl.handleAppLink(uri, promise);
   }

--- a/android/src/oldarch/java/com/RNIterableAPIModule.java
+++ b/android/src/oldarch/java/com/RNIterableAPIModule.java
@@ -139,6 +139,11 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void registerForPush() {
+      moduleImpl.registerForPush();
+    }
+
+    @ReactMethod
     public void handleAppLink(String uri, Promise promise) {
       moduleImpl.handleAppLink(uri, promise);
     }

--- a/ios/RNIterableAPI/RNIterableAPI.mm
+++ b/ios/RNIterableAPI/RNIterableAPI.mm
@@ -230,6 +230,10 @@ RCT_EXPORT_MODULE()
   [_swiftAPI disableDeviceForCurrentUser];
 }
 
+- (void)registerForPush {
+  [_swiftAPI registerForPush];
+}
+
 - (void)getLastPushPayload:(RCTPromiseResolveBlock)resolve
                     reject:(RCTPromiseRejectBlock)reject {
   [_swiftAPI getLastPushPayload:resolve rejecter:reject];
@@ -510,6 +514,10 @@ RCT_EXPORT_METHOD(setAttributionInfo : (NSDictionary *)attributionInfo) {
 
 RCT_EXPORT_METHOD(disableDeviceForCurrentUser) {
   [_swiftAPI disableDeviceForCurrentUser];
+}
+
+RCT_EXPORT_METHOD(registerForPush) {
+  [_swiftAPI registerForPush];
 }
 
 RCT_EXPORT_METHOD(getLastPushPayload : (RCTPromiseResolveBlock)

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -144,6 +144,14 @@ import React
     IterableAPI.disableDeviceForCurrentUser()
   }
 
+  @objc(registerForPush)
+  public func registerForPush() {
+    ITBInfo()
+    DispatchQueue.main.async {
+      UIApplication.shared.registerForRemoteNotifications()
+    }
+  }
+
   @objc(getLastPushPayload:rejecter:)
   public func getLastPushPayload(resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock)
   {

--- a/src/__mocks__/MockRNIterableAPI.ts
+++ b/src/__mocks__/MockRNIterableAPI.ts
@@ -34,6 +34,8 @@ export class MockRNIterableAPI {
 
   static disableDeviceForCurrentUser = jest.fn();
 
+  static registerForPush = jest.fn();
+
   static trackPushOpenWithCampaignId = jest.fn();
 
   static updateCart = jest.fn();

--- a/src/api/NativeRNIterableAPI.ts
+++ b/src/api/NativeRNIterableAPI.ts
@@ -110,6 +110,7 @@ export interface Spec extends TurboModule {
 
   // Device management
   disableDeviceForCurrentUser(): void;
+  registerForPush(): void;
   getLastPushPayload(): Promise<{
     [key: string]: string | number | boolean;
   } | null>;

--- a/src/core/classes/Iterable.test.ts
+++ b/src/core/classes/Iterable.test.ts
@@ -142,6 +142,16 @@ describe('Iterable', () => {
     });
   });
 
+  describe('registerForPush', () => {
+    it('should re-register the device for push notifications', () => {
+      // GIVEN no parameters
+      // WHEN Iterable.registerForPush is called
+      Iterable.registerForPush();
+      // THEN corresponding method is called on RNIterableAPI
+      expect(MockRNIterableAPI.registerForPush).toBeCalled();
+    });
+  });
+
   describe('getLastPushPayload', () => {
     it('should return the last push payload', async () => {
       const result = { var1: 'val1', var2: true };

--- a/src/core/classes/Iterable.ts
+++ b/src/core/classes/Iterable.ts
@@ -346,6 +346,26 @@ export class Iterable {
   }
 
   /**
+   * Re-register the device for push notifications for the current user.
+   *
+   * This method can be used to re-enable push notifications after they have been
+   * disabled by calling `disableDeviceForCurrentUser`. It triggers the native
+   * push registration flow, re-registering the device token with Iterable.
+   *
+   * @example
+   * ```typescript
+   * // First disable push
+   * Iterable.disableDeviceForCurrentUser();
+   *
+   * // Later, re-enable push
+   * Iterable.registerForPush();
+   * ```
+   */
+  static registerForPush() {
+    IterableApi.registerForPush();
+  }
+
+  /**
    * Get the payload of the last push notification with which the user
    * opened the application (by clicking an action button, etc.).
    *

--- a/src/core/classes/IterableApi.test.ts
+++ b/src/core/classes/IterableApi.test.ts
@@ -247,6 +247,17 @@ describe('IterableApi', () => {
     });
   });
 
+  describe('registerForPush', () => {
+    it('should call RNIterableAPI.registerForPush', () => {
+      // GIVEN no parameters
+      // WHEN registerForPush is called
+      IterableApi.registerForPush();
+
+      // THEN RNIterableAPI.registerForPush is called
+      expect(MockRNIterableAPI.registerForPush).toBeCalled();
+    });
+  });
+
   describe('updateUser', () => {
     it('should call RNIterableAPI.updateUser with data fields and merge flag', () => {
       // GIVEN data fields and merge flag

--- a/src/core/classes/IterableApi.ts
+++ b/src/core/classes/IterableApi.ts
@@ -138,6 +138,15 @@ export class IterableApi {
   }
 
   /**
+   * Re-register the device for push notifications for the current user.
+   * This can be used to re-enable push notifications after calling disableDeviceForCurrentUser.
+   */
+  static registerForPush() {
+    IterableLogger.log('registerForPush');
+    return RNIterableAPI.registerForPush();
+  }
+
+  /**
    * Save data to the current user's Iterable profile.
    *
    * @param dataFields - The data fields to update


### PR DESCRIPTION
## Summary
- Add `registerForPush()` method to re-enable push notifications after calling `disableDeviceForCurrentUser()`
- Implemented across all layers: TypeScript interface, native bridge (iOS and Android), both old and new architecture
- Complements existing `disableDeviceForCurrentUser()` method


## Test plan
- [ ] Call `disableDeviceForCurrentUser()`, then call `registerForPush()`, verify push notifications work again
- [ ] Verify `autoPushRegistration` still works as expected
- [ ] Test on both iOS and Android
- [ ] Run unit tests (`yarn jest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)