### PR TITLE
Sumeru / #581 - Fix IterableInAppMessage.createdAt type mismatch causing crashes

### DIFF
--- a/src/__tests__/IterableInApp.test.ts
+++ b/src/__tests__/IterableInApp.test.ts
@@ -178,6 +178,46 @@ describe('Iterable In App', () => {
     );
   });
 
+  test('fromDict_withCreatedAtAndExpiresAt_returnsDateObjects', () => {
+    // GIVEN a message dict with numeric timestamps from the native bridge
+    const createdAtMs = 1609459200000; // 2021-01-01T00:00:00.000Z
+    const expiresAtMs = 1609545600000; // 2021-01-02T00:00:00.000Z
+    const messageDict = {
+      messageId: 'message1',
+      campaignId: 1234,
+      trigger: { type: IterableInAppTriggerType.immediate },
+      createdAt: createdAtMs,
+      expiresAt: expiresAtMs,
+      priorityLevel: 300.5,
+    };
+
+    // WHEN fromDict is called
+    const message = IterableInAppMessage.fromDict(messageDict);
+
+    // THEN createdAt and expiresAt are Date objects with the correct values
+    expect(message.createdAt).toBeInstanceOf(Date);
+    expect(message.expiresAt).toBeInstanceOf(Date);
+    expect(message.createdAt?.getTime()).toBe(createdAtMs);
+    expect(message.expiresAt?.getTime()).toBe(expiresAtMs);
+  });
+
+  test('fromDict_withoutCreatedAtAndExpiresAt_returnsUndefined', () => {
+    // GIVEN a message dict without timestamps
+    const messageDict = {
+      messageId: 'message1',
+      campaignId: 1234,
+      trigger: { type: IterableInAppTriggerType.immediate },
+      priorityLevel: 300.5,
+    };
+
+    // WHEN fromDict is called
+    const message = IterableInAppMessage.fromDict(messageDict);
+
+    // THEN createdAt and expiresAt are undefined
+    expect(message.createdAt).toBeUndefined();
+    expect(message.expiresAt).toBeUndefined();
+  });
+
   test('getMessages_noParams_returnsMessages', async () => {
     // GIVEN a list of in-app messages representing the local queue
     const messageDicts = [

--- a/src/inApp/classes/IterableInAppMessage.ts
+++ b/src/inApp/classes/IterableInAppMessage.ts
@@ -175,16 +175,12 @@ export class IterableInAppMessage {
     const campaignId = dict.campaignId;
     const trigger = IterableInAppTrigger.fromDict(dict.trigger);
 
-    let createdAt = dict.createdAt;
-    if (createdAt) {
-      const dateObject = new Date(0);
-      createdAt = dateObject.setUTCMilliseconds(createdAt);
-    }
-    let expiresAt = dict.expiresAt;
-    if (expiresAt) {
-      const dateObject = new Date(0);
-      expiresAt = dateObject.setUTCMilliseconds(expiresAt);
-    }
+    const createdAt = dict.createdAt
+      ? new Date(dict.createdAt)
+      : undefined;
+    const expiresAt = dict.expiresAt
+      ? new Date(dict.expiresAt)
+      : undefined;
     const saveToInbox = IterableUtil.readBoolean(dict, 'saveToInbox');
     const inboxMetadataDict = dict.inboxMetadata;
     let inboxMetadata: IterableInboxMetadata | undefined;
@@ -196,16 +192,12 @@ export class IterableInAppMessage {
     const customPayload = dict.customPayload;
     const read = IterableUtil.readBoolean(dict, 'read');
 
-    const priorityLevel = dict.priorityLevel;
+    const priorityLevel = dict.priorityLevel ?? 0;
 
     return new IterableInAppMessage(
       messageId,
       campaignId,
       trigger,
-      // MOB-10426: Speak to the team about `IterableInAppMessage` requiring a date
-      // object, but being passed a number in this case
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //  @ts-ignore
       createdAt,
       expiresAt,
       saveToInbox,


### PR DESCRIPTION
## Summary
- Fixes type mismatch for `IterableInAppMessage.createdAt` and `expiresAt` that causes runtime crashes
- The native bridge sends epoch milliseconds (number), but `setUTCMilliseconds()` returns a number, not a `Date` — so consumers calling Date methods on `createdAt` would crash
- Replaced with `new Date(milliseconds)` to properly convert timestamps to `Date` objects
- Removed the `@ts-ignore` workaround that was masking the type error
- Added default value for `priorityLevel` to fix exposed type issue

## Test plan
- [x] Added unit test verifying `createdAt` and `expiresAt` return valid `Date` objects from `fromDict`
- [x] Added unit test verifying `undefined` timestamps remain `undefined`
- [ ] Verify no crashes when accessing `createdAt` on in-app messages in a running app
- [ ] Check backward compatibility with existing in-app message flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)