### PR TITLE
Fix createdAt and expiresAt returning numbers instead of Date objects

### DIFF
--- a/src/inApp/classes/IterableInAppMessage.ts
+++ b/src/inApp/classes/IterableInAppMessage.ts
@@ -175,16 +175,8 @@ export class IterableInAppMessage {
     const campaignId = dict.campaignId;
     const trigger = IterableInAppTrigger.fromDict(dict.trigger);
 
-    let createdAt = dict.createdAt;
-    if (createdAt) {
-      const dateObject = new Date(0);
-      createdAt = dateObject.setUTCMilliseconds(createdAt);
-    }
-    let expiresAt = dict.expiresAt;
-    if (expiresAt) {
-      const dateObject = new Date(0);
-      expiresAt = dateObject.setUTCMilliseconds(expiresAt);
-    }
+    const createdAt = dict.createdAt ? new Date(dict.createdAt) : undefined;
+    const expiresAt = dict.expiresAt ? new Date(dict.expiresAt) : undefined;
     const saveToInbox = IterableUtil.readBoolean(dict, 'saveToInbox');
     const inboxMetadataDict = dict.inboxMetadata;
     let inboxMetadata: IterableInboxMetadata | undefined;
@@ -202,10 +194,6 @@ export class IterableInAppMessage {
       messageId,
       campaignId,
       trigger,
-      // MOB-10426: Speak to the team about `IterableInAppMessage` requiring a date
-      // object, but being passed a number in this case
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //  @ts-ignore
       createdAt,
       expiresAt,
       saveToInbox,

--- a/src/inbox/classes/IterableInboxDataModel.ts
+++ b/src/inbox/classes/IterableInboxDataModel.ts
@@ -211,15 +211,7 @@ export class IterableInboxDataModel {
       return '';
     }
 
-    let createdAt;
-
-    if (typeof message.createdAt === 'string') {
-      createdAt = new Date(parseInt(message.createdAt, 10));
-    } else {
-      createdAt = new Date(message.createdAt);
-    }
-
-    const defaultDateString = `${createdAt.toLocaleDateString()} at ${createdAt.toLocaleTimeString()}`;
+    const defaultDateString = `${message.createdAt.toLocaleDateString()} at ${message.createdAt.toLocaleTimeString()}`;
 
     return defaultDateString;
   }


### PR DESCRIPTION
setUTCMilliseconds() returns a numeric timestamp, not a Date object, causing type mismatches and crashes on Android. Replace with new Date() constructor which correctly creates Date objects from millisecond timestamps. Also removes the downstream typeof workaround in defaultDateMapper and the @ts-ignore suppression.

Fixes #581

https://claude.ai/code/session_016EHrcqQDgexLB5xApCxrZj

## 🔹 JIRA Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

> Please provide a brief description of what this pull request does.
