### PR TITLE
[SDK-363] Expose register device token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ docs/
 # Local Netlify folder
 .netlify
 .metals/
+
+# Agents
+.pi/

--- a/.gitignore
+++ b/.gitignore
@@ -96,4 +96,7 @@ docs/
 .metals/
 
 # Agents
+.agent/
+.claude/
+.cursor/
 .pi/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Updates
+- Added `Iterable.registerDeviceToken(token)` to re-enable push for the current device.
+  - Android accepts an FCM token string.
+  - iOS accepts a continuous hex string representation of the APNS token.
+
 ## 3.0.0
 
 ### Updates

--- a/android/src/main/java/com/iterable/reactnative/RNIterableAPIModuleImpl.java
+++ b/android/src/main/java/com/iterable/reactnative/RNIterableAPIModuleImpl.java
@@ -373,6 +373,11 @@ public class RNIterableAPIModuleImpl implements IterableUrlHandler, IterableCust
         IterableApi.getInstance().disablePush();
     }
 
+    public void registerDeviceToken(String token) {
+        IterableLogger.v(TAG, "registerDeviceToken");
+        IterableApi.getInstance().registerDeviceToken(token);
+    }
+
     public void handleAppLink(String uri, Promise promise) {
         IterableLogger.printInfo();
         promise.resolve(IterableApi.getInstance().handleAppLink(uri));

--- a/android/src/newarch/java/com/RNIterableAPIModule.java
+++ b/android/src/newarch/java/com/RNIterableAPIModule.java
@@ -138,6 +138,11 @@ public class RNIterableAPIModule extends NativeRNIterableAPISpec {
   }
 
   @Override
+  public void registerDeviceToken(String token) {
+    moduleImpl.registerDeviceToken(token);
+  }
+
+  @Override
   public void handleAppLink(String uri, Promise promise) {
     moduleImpl.handleAppLink(uri, promise);
   }

--- a/android/src/oldarch/java/com/RNIterableAPIModule.java
+++ b/android/src/oldarch/java/com/RNIterableAPIModule.java
@@ -139,6 +139,11 @@ public class RNIterableAPIModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void registerDeviceToken(String token) {
+      moduleImpl.registerDeviceToken(token);
+    }
+
+    @ReactMethod
     public void handleAppLink(String uri, Promise promise) {
       moduleImpl.handleAppLink(uri, promise);
     }

--- a/example/ios/ReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/ReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		77E3B5772EA71A4B001449CE /* IterableJwtGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E3B5742EA71A4B001449CE /* IterableJwtGenerator.swift */; };
 		77E3B5782EA71A4B001449CE /* JwtTokenModule.mm in Sources */ = {isa = PBXBuildFile; fileRef = 77E3B5752EA71A4B001449CE /* JwtTokenModule.mm */; };
 		77E3B5792EA71A4B001449CE /* JwtTokenModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77E3B5762EA71A4B001449CE /* JwtTokenModule.swift */; };
-		7C8CB9778D44155D232C3690 /* libPods-ReactNativeSdkExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FC8A71BC6B8F9B2B3CF98A77 /* libPods-ReactNativeSdkExample.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		A3A40C20801B8F02005FA4C0 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 1FC6B09E65A7BD9F6864C5D8 /* PrivacyInfo.xcprivacy */; };
 		DDD9C96E1785FEF10EEE61A5 /* libPods-ReactNativeSdkExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 627B7C7165CE568DB5CB8F50 /* libPods-ReactNativeSdkExample.a */; };

--- a/example/ios/ReactNativeSdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/ReactNativeSdkExample.xcodeproj/project.pbxproj
@@ -438,7 +438,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = iterable.reactnativesdk.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.iterable.reactnativesdk.example;
 				PRODUCT_NAME = ReactNativeSdkExample;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "ReactNativeSdkExample-Bridging-Header.h";
@@ -469,7 +469,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = iterable.reactnativesdk.example;
+				PRODUCT_BUNDLE_IDENTIFIER = com.iterable.reactnativesdk.example;
 				PRODUCT_NAME = ReactNativeSdkExample;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "ReactNativeSdkExample-Bridging-Header.h";

--- a/example/ios/ReactNativeSdkExample/ReactNativeSdkExample.entitlements
+++ b/example/ios/ReactNativeSdkExample/ReactNativeSdkExample.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
 </plist>

--- a/ios/RNIterableAPI/RNIterableAPI.mm
+++ b/ios/RNIterableAPI/RNIterableAPI.mm
@@ -230,6 +230,10 @@ RCT_EXPORT_MODULE()
   [_swiftAPI disableDeviceForCurrentUser];
 }
 
+- (void)registerDeviceToken:(NSString *)token {
+  [_swiftAPI registerDeviceToken:token];
+}
+
 - (void)getLastPushPayload:(RCTPromiseResolveBlock)resolve
                     reject:(RCTPromiseRejectBlock)reject {
   [_swiftAPI getLastPushPayload:resolve rejecter:reject];
@@ -510,6 +514,10 @@ RCT_EXPORT_METHOD(setAttributionInfo : (NSDictionary *)attributionInfo) {
 
 RCT_EXPORT_METHOD(disableDeviceForCurrentUser) {
   [_swiftAPI disableDeviceForCurrentUser];
+}
+
+RCT_EXPORT_METHOD(registerDeviceToken : (NSString *)token) {
+  [_swiftAPI registerDeviceToken:token];
 }
 
 RCT_EXPORT_METHOD(getLastPushPayload : (RCTPromiseResolveBlock)

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -610,7 +610,8 @@ import React
   private let inboxSessionManager = InboxSessionManager()
 
   private func data(fromHex hex: String) -> Data? {
-    var data = Data()
+    guard !hex.isEmpty, hex.count.isMultiple(of: 2) else { return nil }
+    var data = Data(capacity: hex.count / 2)
     var chars = hex.makeIterator()
     while let high = chars.next(), let low = chars.next() {
       guard let highValue = high.hexDigitValue, let lowValue = low.hexDigitValue else {

--- a/ios/RNIterableAPI/ReactIterableAPI.swift
+++ b/ios/RNIterableAPI/ReactIterableAPI.swift
@@ -144,6 +144,16 @@ import React
     IterableAPI.disableDeviceForCurrentUser()
   }
 
+  @objc(registerDeviceToken:)
+  public func registerDeviceToken(token: String) {
+    ITBInfo()
+    guard let tokenData = data(fromHex: token) else {
+      ITBError("Could not convert token to Data: invalid hex string")
+      return
+    }
+    IterableAPI.register(token: tokenData)
+  }
+
   @objc(getLastPushPayload:rejecter:)
   public func getLastPushPayload(resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock)
   {
@@ -598,6 +608,18 @@ import React
   private var authHandlerSemaphore = DispatchSemaphore(value: 0)
 
   private let inboxSessionManager = InboxSessionManager()
+
+  private func data(fromHex hex: String) -> Data? {
+    var data = Data()
+    var chars = hex.makeIterator()
+    while let high = chars.next(), let low = chars.next() {
+      guard let highValue = high.hexDigitValue, let lowValue = low.hexDigitValue else {
+        return nil
+      }
+      data.append(UInt8(highValue << 4 | lowValue))
+    }
+    return data
+  }
 
   @objc func initialize(
     withApiKey apiKey: String,

--- a/src/__mocks__/MockRNIterableAPI.ts
+++ b/src/__mocks__/MockRNIterableAPI.ts
@@ -34,6 +34,10 @@ export class MockRNIterableAPI {
 
   static disableDeviceForCurrentUser = jest.fn();
 
+  static registerDeviceToken = jest.fn((token: string): void => {
+    MockRNIterableAPI.token = token;
+  });
+
   static trackPushOpenWithCampaignId = jest.fn();
 
   static updateCart = jest.fn();

--- a/src/api/NativeRNIterableAPI.ts
+++ b/src/api/NativeRNIterableAPI.ts
@@ -120,6 +120,7 @@ export interface Spec extends TurboModule {
 
   // Device management
   disableDeviceForCurrentUser(): void;
+  registerDeviceToken(token: string): void;
   getLastPushPayload(): Promise<{
     [key: string]: string | number | boolean;
   } | null>;

--- a/src/core/classes/Iterable.test.ts
+++ b/src/core/classes/Iterable.test.ts
@@ -142,6 +142,17 @@ describe('Iterable', () => {
     });
   });
 
+  describe('registerDeviceToken', () => {
+    it('should register the device token for the current user', () => {
+      // GIVEN a device token
+      const token = 'test-device-token';
+      // WHEN Iterable.registerDeviceToken is called
+      Iterable.registerDeviceToken(token);
+      // THEN corresponding method is called on RNIterableAPI
+      expect(MockRNIterableAPI.registerDeviceToken).toBeCalledWith(token);
+    });
+  });
+
   describe('getLastPushPayload', () => {
     it('should return the last push payload', async () => {
       const result = { var1: 'val1', var2: true };

--- a/src/core/classes/Iterable.ts
+++ b/src/core/classes/Iterable.ts
@@ -346,6 +346,26 @@ export class Iterable {
   }
 
   /**
+   * Register the device's token for the current user, re-enabling push notifications.
+   *
+   * @param token - The device token to register.
+   * On Android, pass the Firebase Cloud Messaging (FCM) token string.
+   * On iOS, pass the Apple Push Notification service (APNS) token as a continuous hex string.
+   *
+   * @example
+   * ```typescript
+   * // Android
+   * Iterable.registerDeviceToken('fcm-token-string');
+   *
+   * // iOS
+   * Iterable.registerDeviceToken('abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234');
+   * ```
+   */
+  static registerDeviceToken(token: string) {
+    IterableApi.registerDeviceToken(token);
+  }
+
+  /**
    * Get the payload of the last push notification with which the user
    * opened the application (by clicking an action button, etc.).
    *

--- a/src/core/classes/IterableApi.test.ts
+++ b/src/core/classes/IterableApi.test.ts
@@ -247,6 +247,19 @@ describe('IterableApi', () => {
     });
   });
 
+  describe('registerDeviceToken', () => {
+    it('should call RNIterableAPI.registerDeviceToken with the token', () => {
+      // GIVEN a device token
+      const token = 'test-device-token';
+
+      // WHEN registerDeviceToken is called
+      IterableApi.registerDeviceToken(token);
+
+      // THEN RNIterableAPI.registerDeviceToken is called with the token
+      expect(MockRNIterableAPI.registerDeviceToken).toBeCalledWith(token);
+    });
+  });
+
   describe('updateUser', () => {
     it('should call RNIterableAPI.updateUser with data fields and merge flag', () => {
       // GIVEN data fields and merge flag

--- a/src/core/classes/IterableApi.ts
+++ b/src/core/classes/IterableApi.ts
@@ -138,6 +138,16 @@ export class IterableApi {
   }
 
   /**
+   * Register the device token for the current user, re-enabling push notifications.
+   *
+   * @param token - On Android, the FCM token string. On iOS, a continuous hex string representation of the APNS token.
+   */
+  static registerDeviceToken(token: string) {
+    IterableLogger.log('registerDeviceToken');
+    return RNIterableAPI.registerDeviceToken(token);
+  }
+
+  /**
    * Save data to the current user's Iterable profile.
    *
    * @param dataFields - The data fields to update


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [SDK-363](https://iterable.atlassian.net/browse/SDK-363)

## ✏️ Description

Expose `registerDeviceToken` in React Native bridge:
   - Add `Iterable.registerDeviceToken(token)` public API
   - Add bridge proxy `IterableApi.registerDeviceToken(token)`
   - Add TurboModule spec entry in `NativeRNIterableAPI.ts`
   - Add iOS Swift/Obj-C++ glue with hex-to-Data conversion for APNS tokens
   - Add Android impl + old/new architecture stubs for direct FCM token pass-through
   - Update `MockRNIterableAPI` and unit tests
   - Add CHANGELOG entry under Unreleased

[SDK-363]: https://iterable.atlassian.net/browse/SDK-363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ