### PR TITLE
ci(codeql): use generic iOS Simulator destination for Swift analyze build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -196,7 +196,7 @@ jobs:
           cd ios
           bundle install
           bundle exec pod install
-          xcodebuild -workspace ReactNativeSdkExample.xcworkspace -scheme ReactNativeSdkExample -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 16' build
+          xcodebuild -workspace ReactNativeSdkExample.xcworkspace -scheme ReactNativeSdkExample -configuration Debug -destination 'generic/platform=iOS Simulator' build
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

N/A, CI hotfix.

## ✏️ Description

The Swift CodeQL analyze job (`Build_Analyze_iOS_Example` in `.github/workflows/codeql.yml`) runs on `macos-15` with Xcode 16.4 and was building with:

`-destination 'platform=iOS Simulator,name=iPhone 16'`

Recent runner image revisions (e.g. macos-15-arm64 `20260623.0190.1`) ship without that named simulator preinstalled, so xcodebuild only sees the placeholder "Any iOS Simulator Device" destination and exits with code 70:

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
    { platform:iOS Simulator, OS:latest, name:iPhone 16 }

The requested device could not be found because no available devices matched the request.

Available destinations for the "ReactNativeSdkExample" scheme:
    { platform:iOS, id:dvtdevice-DVTiPhonePlaceholder-iphoneos:placeholder, name:Any iOS Device }
    { platform:iOS Simulator, id:dvtdevice-DVTiOSDeviceSimulatorPlaceholder-iphonesimulator:placeholder, name:Any iOS Simulator Device }
```

This breaks CodeQL Swift analysis on every PR and on master.

### Fix

Switch the destination to `generic/platform=iOS Simulator`. The build only needs to compile so the CodeQL Swift extractor can observe it, no booted device is required. The generic destination matches the always-available "Any iOS Simulator Device" placeholder, removes the dependency on which iPhone the runner image happens to ship, and is robust to future image bumps.

### Test plan

- [ ] CodeQL Advanced workflow's \`Analyze (swift)\` job goes green on this PR.
- [ ] The xcodebuild step completes the build (not just the destination resolution).