### PR TITLE
feat(SDK-521): tighten TurboModule bridge type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
   - Android accepts an FCM token string.
   - iOS accepts a continuous hex string representation of the APNS token.
 
+### Internal
+
+- Tightened TurboModule spec type safety in `NativeRNIterableAPI.ts` (SDK-521, Phase 1).
+  - Replaced `{ [key: string]: string | number | boolean }` dictionaries on the fixed-shape bridge methods (`updateCart`, `trackPurchase`, `setAttributionInfo`, `getAttributionInfo`, `startSession`, `updateVisibleRows`) with inline interfaces (`CommerceItemSpec`, `AttributionInfoSpec`, `InboxImpressionRowSpec`).
+  - No runtime behavior change; native layers read by string key as before. Public facade signatures (`IterableCommerceItem`, `IterableAttributionInfo`, `IterableInboxImpressionRowInfo`) are unchanged and remain structurally compatible — no casts required.
+
 ## 3.0.1
 
 ### Updates

--- a/src/api/NativeRNIterableAPI.ts
+++ b/src/api/NativeRNIterableAPI.ts
@@ -30,6 +30,39 @@ interface EmbeddedMessage {
   payload?: { [key: string]: string | number | boolean | null } | null;
 }
 
+// Inbound fixed-shape structs. Keys are the source of truth and MUST stay in sync
+// with the native decoders that read by string key. See the native `Serialization`
+// files (iOS: ios/RNIterableAPI/Serialization.swift; Android:
+// android/.../Serialization.java) for the authoritative key list per struct:
+//   - CommerceItemSpec ↔ CommerceItem
+//   - InboxImpressionRowSpec ↔ InboxImpressionTracker.RowInfo
+// `dataFields` is `unknown` (not a typed dict): IterableCommerceItem.dataFields is
+// typed `unknown` and is an open consumer-supplied data bag. Codegen accepts
+// `unknown` (maps to GenericObjectTypeAnnotation, same as `Object`).
+interface CommerceItemSpec {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+  sku?: string | null;
+  description?: string | null;
+  url?: string | null;
+  imageUrl?: string | null;
+  categories?: Array<string> | null;
+  dataFields?: unknown;
+}
+
+interface AttributionInfoSpec {
+  campaignId: number;
+  templateId: number;
+  messageId: string;
+}
+
+interface InboxImpressionRowSpec {
+  messageId: string;
+  silentInbox: boolean;
+}
+
 export interface Spec extends TurboModule {
   // Initialization
   initializeWithApiKey(
@@ -94,12 +127,10 @@ export interface Spec extends TurboModule {
   inAppConsume(messageId: string, location: number, source: number): void;
 
   // Commerce
-  updateCart(
-    items: Array<{ [key: string]: string | number | boolean }>
-  ): void;
+  updateCart(items: Array<CommerceItemSpec>): void;
   trackPurchase(
     total: number,
-    items: Array<{ [key: string]: string | number | boolean }>,
+    items: Array<CommerceItemSpec>,
     dataFields?: { [key: string]: string | number | boolean }
   ): void;
 
@@ -111,12 +142,8 @@ export interface Spec extends TurboModule {
   updateEmail(email: string, authToken?: string): void;
 
   // Attribution
-  getAttributionInfo(): Promise<{
-    [key: string]: string | number | boolean;
-  } | null>;
-  setAttributionInfo(
-    dict: { [key: string]: string | number | boolean } | null
-  ): void;
+  getAttributionInfo(): Promise<AttributionInfoSpec | null>;
+  setAttributionInfo(dict: AttributionInfoSpec | null): void;
 
   // Device management
   disableDeviceForCurrentUser(): void;
@@ -144,12 +171,10 @@ export interface Spec extends TurboModule {
   ): void;
 
   // Session tracking
-  startSession(
-    visibleRows: Array<{ [key: string]: string | number | boolean }>
-  ): void;
+  startSession(visibleRows: Array<InboxImpressionRowSpec>): void;
   endSession(): void;
   updateVisibleRows(
-    visibleRows: Array<{ [key: string]: string | number | boolean }>
+    visibleRows: Array<InboxImpressionRowSpec>
   ): void;
 
   // Auth


### PR DESCRIPTION
## 🔹 JIRA Ticket(s) if any

* [SDK-521](https://iterable.atlassian.net/browse/SDK-521)

## ✏️ Description

- Replace dictionary types with inline interfaces (CommerceItemSpec, AttributionInfoSpec, InboxImpressionRowSpec) in NativeRNIterableAPI.ts
- No runtime change; native layers still read by string key
- Public facade and IterableApi.ts unchanged via structural compatibility (no casts)
- dataFields uses `unknown` (Codegen-equivalent to `Object`) to preserve assignability from IterableCommerceItem


[SDK-521]: https://iterable.atlassian.net/browse/SDK-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ